### PR TITLE
Fix error when parsing label files with unexpected chars

### DIFF
--- a/src/Int8BatchStream.cpp
+++ b/src/Int8BatchStream.cpp
@@ -132,21 +132,14 @@ void BatchStream::readCVimage(std::string inputFileName, std::vector<float>& res
 
 void BatchStream::readLabels(std::string inputFileName, std::vector<float>& ris) {
     std::ifstream is(inputFileName.c_str());
-    //read only the first number: the image sub-portion class
-    while (true) {
+    
+    std::string line;
+    while (std::getline(is, line))
+    {
+        std::istringstream iss(line);
         float val;
-		is >> val;
-        if (!is) {
-            break;
-        }
-        // insert the first number and skip all others
+        if(!(iss >> val)) { break; } // error
         ris.push_back(val);
-        while( true ) {
-            char c;
-            is >> c;
-            if (is.peek() == '\n') //detect "\n"
-                break;
-        }   
     }
 }
 


### PR DESCRIPTION
Simple fix that properly reads classes in the label files. Right now having a space before a '\n' character would create an infinite loop. I now properly parse the first number and discard the rest of the line.

Sample file that makes it fail:

```
1 0.9460989583333335 0.46058333333333334 0.04386458333333323 0.09990740740740739 
1 0.4507447916666668 0.2354351851851852 0.056197916666666715 0.09259259259259256 
1 0.9319791666666665 0.5522083333333333 0.06716666666666668 0.12426851851851856 
1 0.6266666666666668 0.3478287037037037 0.054958333333333324 0.1036759259259259 
1 0.8308958333333334 0.5433749999999999 0.07141666666666661 0.12195370370370373 
1 0.3151666666666666 0.1714675925925926 0.05075000000000003 0.07919444444444444 
0 0.5232499999999999 0.30049537037037033 0.012333333333333248 0.01097222222222219 
```