### PR TITLE
Added TensorRT8 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ if(DEBUG)
 endif()
 
 if(TKDNN_PATH)
-    message("SET TKDNN_PATH:"${TKDNN_PATH})
+    message("SET TKDNN_PATH:${TKDNN_PATH}")
     add_definitions(-DTKDNN_PATH="${TKDNN_PATH}")
 else()
     add_definitions(-DTKDNN_PATH="${CMAKE_CURRENT_SOURCE_DIR}")
@@ -51,11 +51,11 @@ find_package(Eigen3 REQUIRED)
 message("Eigen DIR: " ${EIGEN3_INCLUDE_DIR})
 include_directories(${EIGEN3_INCLUDE_DIR})
 
-find_package(OpenCV REQUIRED)
+find_package(OpenCV 4.5 REQUIRED)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DOPENCV")
-# if(OpenCV_CUDA_VERSION)
-#     add_compile_definitions(OPENCV_CUDACONTRIB)
-# endif()
+if(OpenCV_CUDA_VERSION)
+    add_compile_definitions(OPENCV_CUDACONTRIB)
+endif()
 
 # gives problems in cross-compiling, probably malformed cmake config
 find_package(yaml-cpp REQUIRED)
@@ -71,7 +71,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include ${CUDA_INCLUDE_DIRS} ${O
 add_library(tkDNN SHARED ${tkdnn_SRC})
 target_link_libraries(tkDNN ${tkdnn_LIBS})
 
-#static 
+#static
 #add_library(tkDNN_static STATIC ${tkdnn_SRC})
 #target_link_libraries(tkDNN_static ${tkdnn_LIBS})
 
@@ -163,7 +163,7 @@ target_link_libraries(seg_demo tkDNN)
 # Install
 #-------------------------------------------------------------------------------
 #if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-#    set (CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" 
+#    set (CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install"
 #         CACHE PATH "default install path" FORCE)
 #endif()
 message("install dir:" ${CMAKE_INSTALL_PREFIX})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,8 +72,8 @@ add_library(tkDNN SHARED ${tkdnn_SRC})
 target_link_libraries(tkDNN ${tkdnn_LIBS})
 
 #static
-#add_library(tkDNN_static STATIC ${tkdnn_SRC})
-#target_link_libraries(tkDNN_static ${tkdnn_LIBS})
+add_library(tkDNN_static STATIC ${tkdnn_SRC})
+target_link_libraries(tkDNN_static ${tkdnn_LIBS})
 
 # SMALL NETS
 add_executable(test_simple tests/simple/test_simple.cpp)

--- a/include/tkDNN/DetectionNN.h
+++ b/include/tkDNN/DetectionNN.h
@@ -3,10 +3,10 @@
 
 #include <iostream>
 #include <signal.h>
-#include <stdlib.h>    
+#include <stdlib.h>
 #ifdef __linux__
 #include <unistd.h>
-#endif 
+#endif
 
 #include <mutex>
 #include "utils.h"
@@ -17,7 +17,7 @@
 
 #include "tkdnn.h"
 
-//#define OPENCV_CUDACONTRIB //if OPENCV has been compiled with CUDA and contrib.
+#define OPENCV_CUDACONTRIB //if OPENCV has been compiled with CUDA and contrib.
 
 #ifdef OPENCV_CUDACONTRIB
 #include <opencv2/cudawarping.hpp>
@@ -37,7 +37,7 @@ class DetectionNN {
 
         cv::Scalar colors[256];
 
-        int nBatches = 1;
+        int nBatches = 2;
 
 #ifdef OPENCV_CUDACONTRIB
         cv::cuda::GpuMat bgr[3];
@@ -57,11 +57,11 @@ class DetectionNN {
         virtual void preprocess(cv::Mat &frame, const int bi=0) = 0;
 
         /**
-         * This method postprocess the output of the NN to obtain the correct 
-         * boundig boxes. 
-         * 
+         * This method postprocess the output of the NN to obtain the correct
+         * boundig boxes.
+         *
          * @param bi batch index
-         * @param mAP set to true only if all the probabilities for a bounding 
+         * @param mAP set to true only if all the probabilities for a bounding
          *            box are needed, as in some cases for the mAP calculation
          */
         virtual void postprocess(const int bi=0,const bool mAP=false) = 0;
@@ -79,25 +79,25 @@ class DetectionNN {
         ~DetectionNN(){};
 
         /**
-         * Method used to initialize the class, allocate memory and compute 
+         * Method used to initialize the class, allocate memory and compute
          * needed data.
-         * 
+         *
          * @param tensor_path path to the rt file of the NN.
          * @param n_classes number of classes for the given dataset.
          * @param n_batches maximum number of batches to use in inference
          * @return true if everything is correct, false otherwise.
          */
         virtual bool init(const std::string& tensor_path, const int n_classes=80, const int n_batches=1, const float conf_thresh=0.3) = 0;
-        
+
         /**
          * This method performs the whole detection of the NN.
-         * 
+         *
          * @param frames frames to run detection on.
          * @param cur_batches number of batches to use in inference
-         * @param save_times if set to true, preprocess, inference and postprocess times 
+         * @param save_times if set to true, preprocess, inference and postprocess times
          *        are saved on a csv file, otherwise not.
          * @param times pointer to the output stream where to write times
-         * @param mAP set to true only if all the probabilities for a bounding 
+         * @param mAP set to true only if all the probabilities for a bounding
          *            box are needed, as in some cases for the mAP calculation
          */
         void update(std::vector<cv::Mat>& frames, const int cur_batches=1, bool save_times=false, std::ofstream *times=nullptr, const bool mAP=false){
@@ -107,14 +107,14 @@ class DetectionNN {
                 FatalError("A batch size greater than nBatches cannot be used");
 
             originalSize.clear();
-            if(TKDNN_VERBOSE) printCenteredTitle(" TENSORRT detection ", '=', 30); 
+            if(TKDNN_VERBOSE) printCenteredTitle(" TENSORRT detection ", '=', 30);
             {
                 TKDNN_TSTART
                 for(int bi=0; bi<cur_batches;++bi){
                     if(!frames[bi].data)
                         FatalError("No image data feed to detection");
                     originalSize.push_back(frames[bi].size());
-                    preprocess(frames[bi], bi);    
+                    preprocess(frames[bi], bi);
                 }
                 TKDNN_TSTOP
                 if(save_times) *times<<t_ns<<";";
@@ -141,11 +141,11 @@ class DetectionNN {
                 TKDNN_TSTOP
                 if(save_times) *times<<t_ns<<"\n";
             }
-        }      
+        }
 
         /**
          * Method to draw bounding boxes and labels on a frame.
-         * 
+         *
          * @param frames original frame to draw bounding box on.
          */
         void draw(std::vector<cv::Mat>& frames) {
@@ -155,11 +155,11 @@ class DetectionNN {
             std::string det_class;
             int baseline = 0;
             float font_scale = 0.5;
-            int thickness = 2;   
+            int thickness = 2;
 
             for(int bi=0; bi<frames.size(); ++bi){
                 // draw dets
-                for(int i=0; i<batchDetected[bi].size(); i++) { 
+                for(int i=0; i<batchDetected[bi].size(); i++) {
                     b           = batchDetected[bi][i];
                     x0   		= b.x;
                     x1   		= b.x + b.w;
@@ -168,11 +168,11 @@ class DetectionNN {
                     det_class 	= classesNames[b.cl];
 
                     // draw rectangle
-                    cv::rectangle(frames[bi], cv::Point(x0, y0), cv::Point(x1, y1), colors[b.cl], 2); 
+                    cv::rectangle(frames[bi], cv::Point(x0, y0), cv::Point(x1, y1), colors[b.cl], 2);
 
                     // draw label
                     cv::Size text_size = getTextSize(det_class, cv::FONT_HERSHEY_SIMPLEX, font_scale, thickness, &baseline);
-                    cv::rectangle(frames[bi], cv::Point(x0, y0), cv::Point((x0 + text_size.width - 2), (y0 - text_size.height - 2)), colors[b.cl], -1);                      
+                    cv::rectangle(frames[bi], cv::Point(x0, y0), cv::Point((x0 + text_size.width - 2), (y0 - text_size.height - 2)), colors[b.cl], -1);
                     cv::putText(frames[bi], det_class, cv::Point(x0, (y0 - (baseline / 2))), cv::FONT_HERSHEY_SIMPLEX, font_scale, cv::Scalar(255, 255, 255), thickness);
                 }
             }

--- a/include/tkDNN/DetectionNN3D.h
+++ b/include/tkDNN/DetectionNN3D.h
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <signal.h>
 #include <stdlib.h>
-#ifdef __linux__    
+#ifdef __linux__
 #include <unistd.h>
 #endif
 
@@ -17,7 +17,7 @@
 
 #include "tkdnn.h"
 
-// #define OPENCV_CUDACONTRIB //if OPENCV has been compiled with CUDA and contrib.
+#define OPENCV_CUDACONTRIB //if OPENCV has been compiled with CUDA and contrib.
 
 #ifdef OPENCV_CUDACONTRIB
 #include <opencv2/cudawarping.hpp>
@@ -57,11 +57,11 @@ class DetectionNN3D {
         virtual void preprocess(cv::Mat &frame, const int bi=0) = 0;
 
         /**
-         * This method postprocess the output of the NN to obtain the correct 
-         * boundig boxes. 
-         * 
+         * This method postprocess the output of the NN to obtain the correct
+         * boundig boxes.
+         *
          * @param bi batch index
-         * @param mAP set to true only if all the probabilities for a bounding 
+         * @param mAP set to true only if all the probabilities for a bounding
          *            box are needed, as in some cases for the mAP calculation
          */
         virtual void postprocess(const int bi=0,const bool mAP=false) = 0;
@@ -69,7 +69,7 @@ class DetectionNN3D {
     public:
         int classes = 0;
         float confThreshold = 0.3; /*threshold on the confidence of the boxes*/
-        
+
         std::vector<tk::dnn::box3D> detected3D; /*bounding boxes in output*/
         std::vector<std::vector<tk::dnn::box3D>> batchDetected; /*bounding boxes in output*/
         std::vector<double> pre_stats, stats, post_stats, visual_stats; /*keeps track of inference times (ms)*/
@@ -79,29 +79,29 @@ class DetectionNN3D {
         ~DetectionNN3D(){};
 
         /**
-         * Method used to initialize the class, allocate memory and compute 
+         * Method used to initialize the class, allocate memory and compute
          * needed data.
-         * 
+         *
          * @param tensor_path path to the rt file of the NN.
          * @param n_classes number of classes for the given dataset.
          * @param n_batches maximum number of batches to use in inference.
          * @return true if everything is correct, false otherwise.
          */
-        virtual bool init(const std::string& tensor_path, const int n_classes=3, const int n_batches=1, 
+        virtual bool init(const std::string& tensor_path, const int n_classes=3, const int n_batches=1,
                             const float conf_thresh=0.3, const std::vector<cv::Mat>& k_calibs=std::vector<cv::Mat>()) = 0;
 
         /**
          * This method performs the whole detection of the NN.
-         * 
+         *
          * @param frames frames to run detection on.
          * @param cur_batches number of batches to use in inference.
-         * @param save_times if set to true, preprocess, inference and postprocess times 
+         * @param save_times if set to true, preprocess, inference and postprocess times
          *        are saved on a csv file, otherwise not.
          * @param times pointer to the output stream where to write times.
-         * @param mAP set to true only if all the probabilities for a bounding 
+         * @param mAP set to true only if all the probabilities for a bounding
          *            box are needed, as in some cases for the mAP calculation.
          */
-        void update(std::vector<cv::Mat>& frames, const int cur_batches=1, bool save_times=false, 
+        void update(std::vector<cv::Mat>& frames, const int cur_batches=1, bool save_times=false,
                     std::ofstream *times=nullptr, const bool mAP=false){
             if(save_times && times==nullptr)
                 FatalError("save_times set to true, but no valid ofstream given");
@@ -109,17 +109,17 @@ class DetectionNN3D {
                 FatalError("A batch size greater than nBatches cannot be used");
 
             originalSize.clear();
-            if(TKDNN_VERBOSE) printCenteredTitle(" TENSORRT detection ", '=', 30); 
+            if(TKDNN_VERBOSE) printCenteredTitle(" TENSORRT detection ", '=', 30);
             {
                 TKDNN_TSTART
                 for(int bi=0; bi<cur_batches;++bi){
                     if(!frames[bi].data)
                         FatalError("No image data feed to detection");
                     originalSize.push_back(frames[bi].size());
-                    preprocess(frames[bi], bi);   
+                    preprocess(frames[bi], bi);
                 }
                 TKDNN_TSTOP
-                pre_stats.push_back(t_ns); 
+                pre_stats.push_back(t_ns);
                 if(save_times) *times<<t_ns<<";";
             }
 
@@ -149,11 +149,11 @@ class DetectionNN3D {
 
         /**
          * Method to draw bounding boxes and labels on a frame.
-         * 
+         *
          * @param frames original frame to draw bounding box on.
-         */    
+         */
         virtual void draw(std::vector<cv::Mat>& frames){};
-          
+
 };
 
 }}

--- a/include/tkDNN/Int8BatchStream.h
+++ b/include/tkDNN/Int8BatchStream.h
@@ -12,7 +12,7 @@
 #include <iomanip>
 #include <signal.h>
 #include <stdlib.h>
-#ifdef __linux__    
+#ifdef __linux__
 #include <unistd.h>
 #endif
 
@@ -23,9 +23,9 @@
 #include "tkdnn.h"
 
 /*
- * BatchStream implements the stream for the INT8 calibrator. 
- * It reads the two files .txt with the list of image file names 
- * and the list of label file names. 
+ * BatchStream implements the stream for the INT8 calibrator.
+ * It reads the two files .txt with the list of image file names
+ * and the list of label file names.
  * It then iterates on images and labels.
  */
 class BatchStream {
@@ -39,7 +39,7 @@ public:
 	float *getLabels() { return mLabels.data(); }
 	int getBatchesRead() const { return mBatchCount; }
 	int getBatchSize() const { return mBatchSize; }
-	nvinfer1::DimsNCHW getDims() const { return mDims; }
+	nvinfer1::Dims4 getDims() const { return mDims; }
 	float* getFileBatch() { return &mFileBatch[0]; }
 	float* getFileLabels() { return &mFileLabels[0]; }
 	void readInListFile(const std::string& dataFilePath, std::vector<std::string>& mListIn);
@@ -55,7 +55,7 @@ private:
 	int mFileBatchPos{ 0 };
 	int mImageSize{ 0 };
 
-	nvinfer1::DimsNCHW mDims;
+	nvinfer1::Dims4 mDims;
 	std::vector<float> mBatch;
 	std::vector<float> mLabels;
 	std::vector<float> mFileBatch;

--- a/include/tkDNN/Int8Calibrator.h
+++ b/include/tkDNN/Int8Calibrator.h
@@ -20,20 +20,20 @@
 
 /*
  * Int8EntropyCalibrator implements the INT8 calibrator to achieve the
- * INT8 quantization. It uses a BatchStream stream to scroll through 
- * images data. It also implements the calibration cache, a way to 
- * save the calibration process results to reduce the running time: 
+ * INT8 quantization. It uses a BatchStream stream to scroll through
+ * images data. It also implements the calibration cache, a way to
+ * save the calibration process results to reduce the running time:
  * the calibration process takes a long time.
  */
 class Int8EntropyCalibrator : public nvinfer1::IInt8EntropyCalibrator {
 public:
-	Int8EntropyCalibrator(BatchStream& stream, int firstBatch, const std::string& calibTableFilePath, 
+	Int8EntropyCalibrator(BatchStream& stream, int firstBatch, const std::string& calibTableFilePath,
 							const std::string& inputBlobName, bool readCache = true);
 	virtual ~Int8EntropyCalibrator() { checkCuda(cudaFree(mDeviceInput)); }
-	int getBatchSize() const override { return mStream.getBatchSize(); }
-	bool getBatch(void* bindings[], const char* names[], int nbBindings) override;
-	const void* readCalibrationCache(size_t& length) override;
-	void writeCalibrationCache(const void* cache, size_t length) override;
+	int getBatchSize() const noexcept override { return mStream.getBatchSize(); }
+	bool getBatch(void* bindings[], const char* names[], int nbBindings) noexcept override;
+	const void* readCalibrationCache(size_t& length) noexcept override;
+	void writeCalibrationCache(const void* cache, size_t length) noexcept override;
 
 private:
 	BatchStream mStream;

--- a/include/tkDNN/NetworkRT.h
+++ b/include/tkDNN/NetworkRT.h
@@ -2,28 +2,14 @@
 #define NETWORKRT_H
 
 #include <string.h> // memcpy
+#include <memory>
+
 #include "utils.h"
 #include "Network.h"
 #include "Layer.h"
 #include "NvInfer.h"
-#include <memory>
 
-namespace tk { namespace dnn {
-
-template<typename T> void writeBUF(char*& buffer, const T& val)
-{
-    *reinterpret_cast<T*>(buffer) = val;
-    buffer += sizeof(T);
-}
-
-template<typename T> T readBUF(const char*& buffer)
-{
-    T val = *reinterpret_cast<const T*>(buffer);
-    buffer += sizeof(T);
-    return val;
-}
-
-using namespace nvinfer1;
+// using namespace nvinfer1;
 #include "pluginsRT/ActivationLeakyRT.h"
 #include "pluginsRT/ActivationLogisticRT.h"
 #include "pluginsRT/ActivationReLUCeilingRT.h"
@@ -40,16 +26,7 @@ using namespace nvinfer1;
 #include "pluginsRT/ReshapeRT.h"
 #include "pluginsRT/MaxPoolingFixedSizeRT.h"
 
-class PluginFactory : IPluginFactory
-{
-public:
-    YoloRT *yolos[16];
-    int n_yolos;
-
-	virtual IPlugin* createPlugin(const char* layerName, const void* serialData, size_t serialLength);
-};
-
-
+namespace tk { namespace dnn {
 
 class NetworkRT {
 
@@ -57,11 +34,11 @@ public:
     nvinfer1::DataType dtRT;
     nvinfer1::IBuilder *builderRT;
     nvinfer1::IRuntime *runtimeRT;
-    nvinfer1::INetworkDefinition *networkRT; 
-#if NV_TENSORRT_MAJOR >= 6  
+    nvinfer1::INetworkDefinition *networkRT;
+#if NV_TENSORRT_MAJOR >= 6
     nvinfer1::IBuilderConfig *configRT;
 #endif
-    
+
     nvinfer1::ICudaEngine *engineRT;
     nvinfer1::IExecutionContext *contextRT;
 
@@ -73,8 +50,6 @@ public:
     dataDim_t input_dim, output_dim;
     dnnType *output;
     cudaStream_t stream;
-
-    PluginFactory *pluginFactory;
 
     NetworkRT(Network *net, const char *name);
     virtual ~NetworkRT();
@@ -89,7 +64,7 @@ public:
     int getBuffersN() {
         if(engineRT != nullptr)
             return engineRT->getNbBindings();
-        else 
+        else
             return 0;
     }
 
@@ -97,7 +72,7 @@ public:
         Do inference
     */
     dnnType* infer(dataDim_t &dim, dnnType* data);
-    void enqueue(int batchSize = 1);    
+    void enqueue(int batchSize = 1);
 
     nvinfer1::ILayer* convert_layer(nvinfer1::ITensor *input, Layer *l);
     nvinfer1::ILayer* convert_layer(nvinfer1::ITensor *input, Conv2d *l);

--- a/include/tkDNN/buffer_func.h
+++ b/include/tkDNN/buffer_func.h
@@ -1,0 +1,20 @@
+#ifndef BUFFER_FUNC_H
+#define BUFFER_FUNC_H
+
+namespace tk { namespace dnn {
+
+template<typename T> void writeBUF(char*& buffer, const T& val)
+{
+    *reinterpret_cast<T*>(buffer) = val;
+    buffer += sizeof(T);
+}
+
+template<typename T> T readBUF(const char*& buffer)
+{
+    T val = *reinterpret_cast<const T*>(buffer);
+    buffer += sizeof(T);
+    return val;
+}
+}}
+
+#endif // BUFFER_FUNC_H

--- a/include/tkDNN/pluginsRT/ActivationLogisticRT.h
+++ b/include/tkDNN/pluginsRT/ActivationLogisticRT.h
@@ -70,7 +70,7 @@ public:
 
     // Extra IPluginV2 overrides
     bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
-        return true;
+        return (type == nvinfer1::DataType::kFLOAT && format == nvinfer1::PluginFormat::kLINEAR);
     }
 
     nvinfer1::IPluginV2 * clone() const noexcept override {

--- a/include/tkDNN/pluginsRT/ActivationLogisticRT.h
+++ b/include/tkDNN/pluginsRT/ActivationLogisticRT.h
@@ -1,60 +1,149 @@
-#include<cassert>
-#include "../kernels.h"
+#ifndef ACTIVATION_LOGISTIC_RT_H
+#define ACTIVATION_LOGISTIC_RT_H
 
-class ActivationLogisticRT : public IPlugin {
+#include <cassert>
+#include <vector>
+
+#include <NvInferRuntimeCommon.h>
+#include <NvInfer.h>
+
+#include "../kernels.h"
+#include "../buffer_func.h"
+
+#define PLUGIN_NAME "ActivationLogistic"
+#define PLUGIN_VERSION "1"
+
+namespace tk { namespace dnn {
+
+class ActivationLogisticRT final : public nvinfer1::IPluginV2 {
 
 public:
-    ActivationLogisticRT() {
+    ActivationLogisticRT() = default;
 
+    ~ActivationLogisticRT() = default;
 
-    }
-
-    ~ActivationLogisticRT(){
-
-    }
-
-    int getNbOutputs() const override {
+    int getNbOutputs() const noexcept override {
         return 1;
     }
 
-    Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) override {
+    nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs, int nbInputDims) noexcept override {
         return inputs[0];
     }
 
-    void configure(const Dims* inputDims, int nbInputs, const Dims* outputDims, int nbOutputs, int maxBatchSize) override {
+    void configureWithFormat(nvinfer1::Dims const * inputDims,
+            int32_t nbInputs,
+            nvinfer1::Dims const * outputDims,
+            int32_t nbOutputs,
+            nvinfer1::DataType type,
+            nvinfer1::PluginFormat format,
+            int32_t maxBatchSize) noexcept override {
         size = 1;
         for(int i=0; i<outputDims[0].nbDims; i++)
             size *= outputDims[0].d[i];
     }
 
-    int initialize() override {
-
+    int initialize() noexcept override {
         return 0;
     }
 
-    virtual void terminate() override {
+    void terminate() noexcept override {
     }
 
-    virtual size_t getWorkspaceSize(int maxBatchSize) const override {
+    size_t getWorkspaceSize(int maxBatchSize) const noexcept override {
         return 0;
     }
 
-    virtual int enqueue(int batchSize, const void*const * inputs, void** outputs, void* workspace, cudaStream_t stream) override {
-
+    int32_t enqueue(int32_t batchSize, const void* const * inputs, void* const* outputs, void* workspace, cudaStream_t stream) noexcept override {
         activationLOGISTICForward((dnnType*)reinterpret_cast<const dnnType*>(inputs[0]),
                                   reinterpret_cast<dnnType*>(outputs[0]), batchSize*size, stream);
         return 0;
     }
 
-
-    virtual size_t getSerializationSize() override {
+    size_t getSerializationSize() const noexcept override {
         return 1*sizeof(int);
     }
 
-    virtual void serialize(void* buffer) override {
+    void serialize(void* buffer) const noexcept override {
         char *buf = reinterpret_cast<char*>(buffer);
-        tk::dnn::writeBUF(buf, size);
+        writeBUF(buf, size);
     }
 
+    // Extra IPluginV2 overrides
+    bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
+        return true;
+    }
+
+    nvinfer1::IPluginV2 * clone() const noexcept override {
+        auto a = new ActivationLogisticRT(*this);
+        return a;
+    }
+
+    const char* getPluginType() const noexcept override {
+        return PLUGIN_NAME;
+    }
+
+    const char* getPluginVersion() const noexcept override {
+        return PLUGIN_VERSION;
+    }
+
+    void destroy() noexcept override {}
+
+    void setPluginNamespace(const char* pluginNamespace) noexcept override {
+        mNamespace = pluginNamespace;
+    }
+
+    const char* getPluginNamespace() const noexcept override {
+        return mNamespace.c_str();
+    }
+
+    std::string mNamespace;
     int size;
 };
+
+class ActivationLogisticRTCreator final : public nvinfer1::IPluginCreator {
+public:
+    ActivationLogisticRTCreator() = default;
+
+    const char* getPluginName() const noexcept override {
+        return PLUGIN_NAME;
+    }
+
+    const char* getPluginVersion() const noexcept override {
+        return PLUGIN_VERSION;
+    }
+
+    const nvinfer1::PluginFieldCollection* getFieldNames() noexcept override {
+        return &mFC;
+    }
+
+    nvinfer1::IPluginV2* createPlugin(const char* name, const nvinfer1::PluginFieldCollection* fc) noexcept override {
+        std::cout << "Create plugin" << std::endl;
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV2* deserializePlugin(const char* name, const void* serialData, size_t serialLength) noexcept override {
+        const char * buf = reinterpret_cast<const char*>(serialData),*bufCheck = buf;
+        ActivationLogisticRT *a = new ActivationLogisticRT();
+        a->size = readBUF<int>(buf);
+        assert(buf == bufCheck + serialLength);
+        return a;
+    }
+
+    void setPluginNamespace(const char* pluginNamespace) noexcept override {
+        mNamespace = pluginNamespace;
+    }
+
+    const char* getPluginNamespace() const noexcept override {
+        return mNamespace.c_str();
+    }
+
+private:
+    static nvinfer1::PluginFieldCollection mFC;
+    static std::vector<nvinfer1::PluginField> mPluginAttributes;
+    std::string mNamespace;
+};
+}}
+#undef PLUGIN_NAME
+#undef PLUGIN_VERSION
+
+#endif // ACTIVATION_LOGISTIC_RT_H

--- a/include/tkDNN/pluginsRT/ActivationMishRT.h
+++ b/include/tkDNN/pluginsRT/ActivationMishRT.h
@@ -71,7 +71,7 @@ public:
 
 	// Extra IPluginV2 overrides
 	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
-			return true;
+			return (type == nvinfer1::DataType::kFLOAT && format == nvinfer1::PluginFormat::kLINEAR);
 	}
 
 	nvinfer1::IPluginV2 * clone() const noexcept override {

--- a/include/tkDNN/pluginsRT/ActivationReLUCeilingRT.h
+++ b/include/tkDNN/pluginsRT/ActivationReLUCeilingRT.h
@@ -1,63 +1,156 @@
-#include<cassert>
-#include "../kernels.h"
+#ifndef ACTIVATION_RELU_CEILING_RT_H
+#define ACTIVATION_RELU_CEILING_RT_H
 
-class ActivationReLUCeiling : public IPlugin {
+#include <cassert>
+#include <vector>
+
+#include <NvInferRuntimeCommon.h>
+#include <NvInfer.h>
+
+#include "../kernels.h"
+#include "../buffer_func.h"
+
+#define PLUGIN_NAME "ActivationCReLU"
+#define PLUGIN_VERSION "1"
+namespace tk { namespace dnn {
+
+class ActivationReLUCeiling final : public nvinfer1::IPluginV2 {
 
 public:
 	ActivationReLUCeiling(const float ceiling) {
 		this->ceiling = ceiling;
 	}
 
-	~ActivationReLUCeiling(){
+	~ActivationReLUCeiling() = default;
 
-	}
-
-	int getNbOutputs() const override {
+	int getNbOutputs() const noexcept override {
 		return 1;
 	}
 
-	Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) override {
+	nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs, int nbInputDims) noexcept override {
 		return inputs[0];
 	}
 
-	void configure(const Dims* inputDims, int nbInputs, const Dims* outputDims, int nbOutputs, int maxBatchSize) override {
+	void configureWithFormat(nvinfer1::Dims const * inputDims,
+					int32_t nbInputs,
+					nvinfer1::Dims const * outputDims,
+					int32_t nbOutputs,
+					nvinfer1::DataType type,
+					nvinfer1::PluginFormat format,
+					int32_t maxBatchSize) noexcept override {
 		size = 1;
 		for(int i=0; i<outputDims[0].nbDims; i++)
 			size *= outputDims[0].d[i];
 	}
 
-	int initialize() override {
+	int initialize() noexcept override {
 
 		return 0;
 	}
 
-	virtual void terminate() override {
+	void terminate() noexcept override {
 	}
 
-	virtual size_t getWorkspaceSize(int maxBatchSize) const override {
+	size_t getWorkspaceSize(int maxBatchSize) const noexcept override {
 		return 0;
 	}
 
-	virtual int enqueue(int batchSize, const void*const * inputs, void** outputs, void* workspace, cudaStream_t stream) override {
-
-		activationReLUCeilingForward((dnnType*)reinterpret_cast<const dnnType*>(inputs[0]), 
+	int32_t enqueue(int32_t batchSize, const void* const * inputs, void* const* outputs, void* workspace, cudaStream_t stream) noexcept override {
+		activationReLUCeilingForward((dnnType*)reinterpret_cast<const dnnType*>(inputs[0]),
 											reinterpret_cast<dnnType*>(outputs[0]), batchSize*size, ceiling, stream);
 		return 0;
 	}
 
-
-	virtual size_t getSerializationSize() override {
+	size_t getSerializationSize() const noexcept override {
 		return 1*sizeof(int) +  1*sizeof(float);
 	}
 
-	virtual void serialize(void* buffer) override {
+	void serialize(void* buffer) const noexcept override {
 		char *buf = reinterpret_cast<char*>(buffer),*a=buf;
-		tk::dnn::writeBUF(buf, ceiling);
-		tk::dnn::writeBUF(buf, size);
+		writeBUF(buf, ceiling);
+		writeBUF(buf, size);
 		assert(buf = a + getSerializationSize());
-		
+
 	}
 
+	// Extra IPluginV2 overrides
+	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
+			return true;
+	}
+
+	nvinfer1::IPluginV2 * clone() const noexcept override {
+			auto a = new ActivationReLUCeiling(*this);
+			return a;
+	}
+
+	const char* getPluginType() const noexcept override {
+			return PLUGIN_NAME;
+	}
+
+	const char* getPluginVersion() const noexcept override {
+			return PLUGIN_VERSION;
+	}
+
+	void destroy() noexcept override {}
+
+	void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+	}
+
+	const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+	}
+
+	std::string mNamespace;
 	int size;
 	float ceiling;
 };
+
+class ActivationReLUCeilingCreator final : public nvinfer1::IPluginCreator {
+public:
+    ActivationReLUCeilingCreator() = default;
+
+    const char* getPluginName() const noexcept override {
+        return PLUGIN_NAME;
+    }
+
+    const char* getPluginVersion() const noexcept override {
+        return PLUGIN_VERSION;
+    }
+
+    const nvinfer1::PluginFieldCollection* getFieldNames() noexcept override {
+        return &mFC;
+    }
+
+    nvinfer1::IPluginV2* createPlugin(const char* name, const nvinfer1::PluginFieldCollection* fc) noexcept override {
+        std::cout << "Create plugin" << std::endl;
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV2* deserializePlugin(const char* name, const void* serialData, size_t serialLength) noexcept override {
+			const char * buf = reinterpret_cast<const char*>(serialData),*bufCheck = buf;
+			float activationReluTemp = readBUF<float>(buf);
+			ActivationReLUCeiling* a = new ActivationReLUCeiling(activationReluTemp);
+			a->size = readBUF<int>(buf);
+			assert(buf == bufCheck + serialLength);
+			return a;
+		}
+
+    void setPluginNamespace(const char* pluginNamespace) noexcept override {
+        mNamespace = pluginNamespace;
+    }
+
+    const char* getPluginNamespace() const noexcept override {
+        return mNamespace.c_str();
+    }
+
+private:
+    static nvinfer1::PluginFieldCollection mFC;
+    static std::vector<nvinfer1::PluginField> mPluginAttributes;
+    std::string mNamespace;
+};
+}}
+#undef PLUGIN_NAME
+#undef PLUGIN_VERSION
+
+#endif // ACTIVATION_RELU_CEILING_RT_H

--- a/include/tkDNN/pluginsRT/ActivationReLUCeilingRT.h
+++ b/include/tkDNN/pluginsRT/ActivationReLUCeilingRT.h
@@ -75,7 +75,7 @@ public:
 
 	// Extra IPluginV2 overrides
 	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
-			return true;
+			return (type == nvinfer1::DataType::kFLOAT && format == nvinfer1::PluginFormat::kLINEAR);
 	}
 
 	nvinfer1::IPluginV2 * clone() const noexcept override {

--- a/include/tkDNN/pluginsRT/ActivationSigmoidRT.h
+++ b/include/tkDNN/pluginsRT/ActivationSigmoidRT.h
@@ -1,61 +1,149 @@
-#include<cassert>
-#include "../kernels.h"
+#ifndef ACTIVATION_SIGMOID_RT_H
+#define ACTIVATION_SIGMOID_RT_H
 
-class ActivationSigmoidRT : public IPlugin {
+#include <cassert>
+#include <vector>
+
+#include <NvInferRuntimeCommon.h>
+#include <NvInfer.h>
+
+#include "../kernels.h"
+#include "../buffer_func.h"
+
+#define PLUGIN_NAME "ActivationSigmoidRT"
+#define PLUGIN_VERSION "1"
+namespace tk { namespace dnn {
+
+class ActivationSigmoidRT final : public nvinfer1::IPluginV2 {
 
 public:
-	ActivationSigmoidRT() {
+	ActivationSigmoidRT() = default;
 
+	~ActivationSigmoidRT() = default;
 
-	}
-
-	~ActivationSigmoidRT(){
-
-	}
-
-	int getNbOutputs() const override {
+	int getNbOutputs() const noexcept override {
 		return 1;
 	}
 
-	Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) override {
+	nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs, int nbInputDims) noexcept override {
 		return inputs[0];
 	}
 
-	void configure(const Dims* inputDims, int nbInputs, const Dims* outputDims, int nbOutputs, int maxBatchSize) override {
+	void configureWithFormat(nvinfer1::Dims const * inputDims,
+					int32_t nbInputs,
+					nvinfer1::Dims const * outputDims,
+					int32_t nbOutputs,
+					nvinfer1::DataType type,
+					nvinfer1::PluginFormat format,
+					int32_t maxBatchSize) noexcept override {
 		size = 1;
 		for(int i=0; i<outputDims[0].nbDims; i++)
 			size *= outputDims[0].d[i];
 	}
 
-	int initialize() override {
-
+	int initialize() noexcept override {
 		return 0;
 	}
 
-	virtual void terminate() override {
+	void terminate() noexcept override {
 	}
 
-	virtual size_t getWorkspaceSize(int maxBatchSize) const override {
+	size_t getWorkspaceSize(int maxBatchSize) const noexcept override {
 		return 0;
 	}
 
-	virtual int enqueue(int batchSize, const void*const * inputs, void** outputs, void* workspace, cudaStream_t stream) override {
-
-		activationSIGMOIDForward((dnnType*)reinterpret_cast<const dnnType*>(inputs[0]), 
+	int32_t enqueue(int32_t batchSize, const void* const * inputs, void* const* outputs, void* workspace, cudaStream_t stream) noexcept override {
+		activationSIGMOIDForward((dnnType*)reinterpret_cast<const dnnType*>(inputs[0]),
 											reinterpret_cast<dnnType*>(outputs[0]), batchSize*size, stream);
 		return 0;
 	}
 
-
-	virtual size_t getSerializationSize() override {
+	size_t getSerializationSize() const noexcept override {
 		return 1*sizeof(int);
 	}
 
-	virtual void serialize(void* buffer) override {
+	void serialize(void* buffer) const noexcept override {
 		char *buf = reinterpret_cast<char*>(buffer),*a=buf;
-		tk::dnn::writeBUF(buf, size);
+		writeBUF(buf, size);
 		assert(buf == a + getSerializationSize());
 	}
 
+	// Extra IPluginV2 overrides
+	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
+			return true;
+	}
+
+	nvinfer1::IPluginV2 * clone() const noexcept override {
+			auto a = new ActivationSigmoidRT(*this);
+			return a;
+	}
+
+	const char* getPluginType() const noexcept override {
+			return PLUGIN_NAME;
+	}
+
+	const char* getPluginVersion() const noexcept override {
+			return PLUGIN_VERSION;
+	}
+
+	void destroy() noexcept override {}
+
+	void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+	}
+
+	const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+	}
+
+	std::string mNamespace;
 	int size;
 };
+
+class ActivationSigmoidRTCreator final : public nvinfer1::IPluginCreator {
+public:
+    ActivationSigmoidRTCreator() = default;
+
+    const char* getPluginName() const noexcept override {
+        return PLUGIN_NAME;
+    }
+
+    const char* getPluginVersion() const noexcept override {
+        return PLUGIN_VERSION;
+    }
+
+    const nvinfer1::PluginFieldCollection* getFieldNames() noexcept override {
+        return &mFC;
+    }
+
+    nvinfer1::IPluginV2* createPlugin(const char* name, const nvinfer1::PluginFieldCollection* fc) noexcept override {
+        std::cout << "Create plugin" << std::endl;
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV2* deserializePlugin(const char* name, const void* serialData, size_t serialLength) noexcept override {
+			const char * buf = reinterpret_cast<const char*>(serialData),*bufCheck = buf;
+			ActivationSigmoidRT* a = new ActivationSigmoidRT();
+			a->size = readBUF<int>(buf);
+			assert(buf == bufCheck + serialLength);
+			return a;
+		}
+
+    void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+		}
+
+    const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+		}
+
+private:
+    static nvinfer1::PluginFieldCollection mFC;
+    static std::vector<nvinfer1::PluginField> mPluginAttributes;
+    std::string mNamespace;
+};
+}}
+#undef PLUGIN_NAME
+#undef PLUGIN_VERSION
+
+#endif // ACTIVATION_SIGMOID_RT_H

--- a/include/tkDNN/pluginsRT/ActivationSigmoidRT.h
+++ b/include/tkDNN/pluginsRT/ActivationSigmoidRT.h
@@ -70,7 +70,7 @@ public:
 
 	// Extra IPluginV2 overrides
 	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
-			return true;
+			return (type == nvinfer1::DataType::kFLOAT && format == nvinfer1::PluginFormat::kLINEAR);
 	}
 
 	nvinfer1::IPluginV2 * clone() const noexcept override {

--- a/include/tkDNN/pluginsRT/DeformableConvRT.h
+++ b/include/tkDNN/pluginsRT/DeformableConvRT.h
@@ -1,16 +1,27 @@
-#include<cassert>
+#ifndef DEFORMABLE_CONV_RT_H
+#define DEFORMABLE_CONV_RT_H
+
+#include <cassert>
+#include <vector>
+
+#include <NvInferRuntimeCommon.h>
+#include <NvInfer.h>
+
 #include "../kernels.h"
+#include "../buffer_func.h"
+#include "../Layer.h"
 
+#define PLUGIN_NAME "Deformable"
+#define PLUGIN_VERSION "1"
+namespace tk { namespace dnn {
 
-class DeformableConvRT : public IPlugin {
-
-
+class DeformableConvRT final : public nvinfer1::IPluginV2 {
 
 public:
-	DeformableConvRT(int chunk_dim, int kh, int kw, int sh, int sw, int ph, int pw, 
-					int deformableGroup, int i_n, int i_c, int i_h, int i_w, 
-					int o_n, int o_c, int o_h, int o_w, 
-					tk::dnn::DeformConv2d *deformable = nullptr) {
+	DeformableConvRT(int chunk_dim, int kh, int kw, int sh, int sw, int ph, int pw,
+					int deformableGroup, int i_n, int i_c, int i_h, int i_w,
+					int o_n, int o_c, int o_h, int o_w,
+					DeformConv2d *deformable = nullptr) {
 		this->chunk_dim = chunk_dim;
 		this->kh = kh;
 		this->kw = kw;
@@ -30,7 +41,7 @@ public:
 		height_ones = (i_h + 2 * ph - (1 * (kh - 1) + 1)) / sh + 1;
 		width_ones = (i_w + 2 * pw - (1 * (kw - 1) + 1)) / sw + 1;
 		dim_ones = i_c * kh * kw * 1 * height_ones * width_ones;
-		
+
 		checkCuda( cudaMalloc(&data_d, i_c * o_c * kh * kw * 1 * sizeof(dnnType)));
 		checkCuda( cudaMalloc(&bias2_d, o_c*sizeof(dnnType)));
 		checkCuda( cudaMalloc(&ones_d1, height_ones * width_ones * sizeof(dnnType)));
@@ -61,38 +72,45 @@ public:
 		cublasDestroy(handle);
 	}
 
-	int getNbOutputs() const override {
+	int getNbOutputs() const noexcept override {
 		return 1;
 	}
 
-	Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) override {
-		return DimsCHW{defRT->output_dim.c, defRT->output_dim.h, defRT->output_dim.w};
+	nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs, int nbInputDims) noexcept override {
+		return nvinfer1::Dims3{defRT->output_dim.c, defRT->output_dim.h, defRT->output_dim.w};
 	}
 
-	void configure(const Dims* inputDims, int nbInputs, const Dims* outputDims, int nbOutputs, int maxBatchSize) override { }
+	void configureWithFormat(nvinfer1::Dims const * inputDims,
+					int32_t nbInputs,
+					nvinfer1::Dims const * outputDims,
+					int32_t nbOutputs,
+					nvinfer1::DataType type,
+					nvinfer1::PluginFormat format,
+					int32_t maxBatchSize) noexcept override {
+	}
 
-	int initialize() override {
+	int initialize() noexcept override {
 		return 0;
 	}
 
-	virtual void terminate() override { }
+	void terminate() noexcept override { }
 
-	virtual size_t getWorkspaceSize(int maxBatchSize) const override {
+	size_t getWorkspaceSize(int maxBatchSize) const noexcept override {
 		return 0;
 	}
 
-	virtual int enqueue(int batchSize, const void*const * inputs, void** outputs, void* workspace, cudaStream_t stream) override {
+	int32_t enqueue(int32_t batchSize, const void* const * inputs, void* const* outputs, void* workspace, cudaStream_t stream) noexcept override {
 		dnnType *srcData = (dnnType*)reinterpret_cast<const dnnType*>(inputs[0]);
 		dnnType *output_conv = (dnnType*)reinterpret_cast<const dnnType*>(inputs[1]);
 
 		// split conv2d outputs into offset to mask
 		for(int b=0; b<batchSize; b++) {
-			checkCuda(cudaMemcpy(offset, output_conv + b * 3 * chunk_dim, 2*chunk_dim*sizeof(dnnType), cudaMemcpyDeviceToDevice)); 
-			checkCuda(cudaMemcpy(mask, output_conv + b * 3 * chunk_dim + 2*chunk_dim, chunk_dim*sizeof(dnnType), cudaMemcpyDeviceToDevice)); 
+			checkCuda(cudaMemcpy(offset, output_conv + b * 3 * chunk_dim, 2*chunk_dim*sizeof(dnnType), cudaMemcpyDeviceToDevice));
+			checkCuda(cudaMemcpy(mask, output_conv + b * 3 * chunk_dim + 2*chunk_dim, chunk_dim*sizeof(dnnType), cudaMemcpyDeviceToDevice));
 			// kernel sigmoid
 			activationSIGMOIDForward(mask, mask, chunk_dim);
 			// deformable convolution
-			dcnV2CudaForward(stat, handle, 
+			dcnV2CudaForward(stat, handle,
 								srcData, data_d,
 								bias2_d, ones_d1,
 								offset, mask,
@@ -109,65 +127,94 @@ public:
 		return 0;
 	}
 
-
-	virtual size_t getSerializationSize() override {
+	size_t getSerializationSize() const noexcept override {
 		return 16 * sizeof(int) + chunk_dim * 3 * sizeof(dnnType) + (i_c * o_c * kh * kw * 1 ) * sizeof(dnnType) +
 			   o_c * sizeof(dnnType) + height_ones * width_ones * sizeof(dnnType) + dim_ones * sizeof(dnnType);
 	}
 
-	virtual void serialize(void* buffer) override {
+	void serialize(void* buffer) const noexcept override {
 		char *buf = reinterpret_cast<char*>(buffer),*a=buf;
-		tk::dnn::writeBUF(buf, chunk_dim);
-		tk::dnn::writeBUF(buf, kh);
-		tk::dnn::writeBUF(buf, kw);
-		tk::dnn::writeBUF(buf, sh);
-		tk::dnn::writeBUF(buf, sw);
-		tk::dnn::writeBUF(buf, ph);
-		tk::dnn::writeBUF(buf, pw);
-		tk::dnn::writeBUF(buf, deformableGroup);
-		tk::dnn::writeBUF(buf, i_n);
-		tk::dnn::writeBUF(buf, i_c);
-		tk::dnn::writeBUF(buf, i_h);
-		tk::dnn::writeBUF(buf, i_w);
-		tk::dnn::writeBUF(buf, o_n);
-		tk::dnn::writeBUF(buf, o_c);
-		tk::dnn::writeBUF(buf, o_h);
-		tk::dnn::writeBUF(buf, o_w);
+		writeBUF(buf, chunk_dim);
+		writeBUF(buf, kh);
+		writeBUF(buf, kw);
+		writeBUF(buf, sh);
+		writeBUF(buf, sw);
+		writeBUF(buf, ph);
+		writeBUF(buf, pw);
+		writeBUF(buf, deformableGroup);
+		writeBUF(buf, i_n);
+		writeBUF(buf, i_c);
+		writeBUF(buf, i_h);
+		writeBUF(buf, i_w);
+		writeBUF(buf, o_n);
+		writeBUF(buf, o_c);
+		writeBUF(buf, o_h);
+		writeBUF(buf, o_w);
 		dnnType *aus = new dnnType[chunk_dim*2];
 		checkCuda( cudaMemcpy(aus, offset, sizeof(dnnType)*2*chunk_dim, cudaMemcpyDeviceToHost) );
         for(int i=0; i<chunk_dim*2; i++)
-    		tk::dnn::writeBUF(buf, aus[i]);
+    		writeBUF(buf, aus[i]);
 		free(aus);
 		aus = new dnnType[chunk_dim];
 		checkCuda( cudaMemcpy(aus, mask, sizeof(dnnType)*chunk_dim, cudaMemcpyDeviceToHost) );
         for(int i=0; i<chunk_dim; i++)
-    		tk::dnn::writeBUF(buf, aus[i]);
+    		writeBUF(buf, aus[i]);
 		free(aus);
 		aus = new dnnType[(i_c * o_c * kh * kw * 1 )];
 		checkCuda( cudaMemcpy(aus, data_d, sizeof(dnnType)*(i_c * o_c * kh * kw * 1 ), cudaMemcpyDeviceToHost) );
         for(int i=0; i<(i_c * o_c * kh * kw * 1 ); i++)
-    		tk::dnn::writeBUF(buf, aus[i]);
+    		writeBUF(buf, aus[i]);
 		free(aus);
 		aus = new dnnType[o_c];
 		checkCuda( cudaMemcpy(aus, bias2_d, sizeof(dnnType)*o_c, cudaMemcpyDeviceToHost) );
         for(int i=0; i < o_c; i++)
-    		tk::dnn::writeBUF(buf, aus[i]);
+    		writeBUF(buf, aus[i]);
 		free(aus);
 		aus = new dnnType[height_ones * width_ones];
 		checkCuda( cudaMemcpy(aus, ones_d1, sizeof(dnnType)*height_ones * width_ones, cudaMemcpyDeviceToHost) );
         for(int i=0; i<height_ones * width_ones; i++)
-    		tk::dnn::writeBUF(buf, aus[i]);
+    		writeBUF(buf, aus[i]);
 		free(aus);
 		aus = new dnnType[dim_ones];
 		checkCuda( cudaMemcpy(aus, ones_d2, sizeof(dnnType)*dim_ones, cudaMemcpyDeviceToHost) );
         for(int i=0; i<dim_ones; i++)
-    		tk::dnn::writeBUF(buf, aus[i]);
+    		writeBUF(buf, aus[i]);
 		free(aus);
 		assert(buf == a + getSerializationSize());
 	}
 
-	cublasStatus_t stat; 
-	cublasHandle_t handle; 
+	// Extra IPluginV2 overrides
+	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
+			return true;
+	}
+
+	nvinfer1::IPluginV2 * clone() const noexcept override {
+			auto a = new DeformableConvRT(*this);
+			return a;
+	}
+
+	const char* getPluginType() const noexcept override {
+			return PLUGIN_NAME;
+	}
+
+	const char* getPluginVersion() const noexcept override {
+			return PLUGIN_VERSION;
+	}
+
+	void destroy() noexcept override {}
+
+	void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+	}
+
+	const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+	}
+
+	std::string mNamespace;
+
+	cublasStatus_t stat;
+	cublasHandle_t handle;
 	int i_n, i_c, i_h, i_w;
 	int o_n, o_c, o_h, o_w;
 	int size;
@@ -179,9 +226,9 @@ public:
 	int height_ones;
 	int width_ones;
 	int dim_ones;
-		
+
 	dnnType *data_d;
-    dnnType *bias2_d;
+  dnnType *bias2_d;
 	dnnType *ones_d1;
 	dnnType * offset;
 	dnnType * mask;
@@ -190,7 +237,100 @@ public:
 	// dnnType *offset_n;
 	// dnnType *mask_n;
 	// dnnType *output_n;
-	
-	
-	tk::dnn::DeformConv2d *defRT;
+
+	DeformConv2d *defRT;
 };
+
+class DeformableConvRTCreator final : public nvinfer1::IPluginCreator {
+public:
+    DeformableConvRTCreator() = default;
+
+    const char* getPluginName() const noexcept override {
+        return PLUGIN_NAME;
+    }
+
+    const char* getPluginVersion() const noexcept override {
+        return PLUGIN_VERSION;
+    }
+
+    const nvinfer1::PluginFieldCollection* getFieldNames() noexcept override {
+        return &mFC;
+    }
+
+    nvinfer1::IPluginV2* createPlugin(const char* name, const nvinfer1::PluginFieldCollection* fc) noexcept override {
+        std::cout << "Create plugin" << std::endl;
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV2* deserializePlugin(const char* name, const void* serialData, size_t serialLength) noexcept override {
+			const char * buf = reinterpret_cast<const char*>(serialData),*bufCheck = buf;
+			int chuck_dimTemp = readBUF<int>(buf);
+			int khTemp = readBUF<int>(buf);
+			int kwTemp = readBUF<int>(buf);
+			int shTemp = readBUF<int>(buf);
+			int swTemp = readBUF<int>(buf);
+			int phTemp = readBUF<int>(buf);
+			int pwTemp = readBUF<int>(buf);
+			int deformableGroupTemp = readBUF<int>(buf);
+			int i_nTemp = readBUF<int>(buf);
+			int i_cTemp = readBUF<int>(buf);
+			int i_hTemp = readBUF<int>(buf);
+			int i_wTemp = readBUF<int>(buf);
+			int o_nTemp = readBUF<int>(buf);
+			int o_cTemp = readBUF<int>(buf);
+			int o_hTemp = readBUF<int>(buf);
+			int o_wTemp = readBUF<int>(buf);
+
+			DeformableConvRT* r = new DeformableConvRT(chuck_dimTemp, khTemp, kwTemp, shTemp, swTemp, phTemp, pwTemp, deformableGroupTemp, i_nTemp, i_cTemp, i_hTemp, i_wTemp, o_nTemp, o_cTemp, o_hTemp, o_wTemp, nullptr);
+			dnnType *aus = new dnnType[r->chunk_dim*2];
+			for(int i=0; i<r->chunk_dim*2; i++)
+			aus[i] = readBUF<dnnType>(buf);
+			checkCuda( cudaMemcpy(r->offset, aus, sizeof(dnnType)*2*r->chunk_dim, cudaMemcpyHostToDevice) );
+					free(aus);
+			aus = new dnnType[r->chunk_dim];
+			for(int i=0; i<r->chunk_dim; i++)
+							aus[i] = readBUF<dnnType>(buf);
+			checkCuda( cudaMemcpy(r->mask, aus, sizeof(dnnType)*r->chunk_dim, cudaMemcpyHostToDevice) );
+					free(aus);
+			aus = new dnnType[(r->i_c * r->o_c * r->kh * r->kw * 1 )];
+			for(int i=0; i<(r->i_c * r->o_c * r->kh * r->kw * 1 ); i++)
+					aus[i] = readBUF<dnnType>(buf);
+			checkCuda( cudaMemcpy(r->data_d, aus, sizeof(dnnType)*(r->i_c * r->o_c * r->kh * r->kw * 1 ), cudaMemcpyHostToDevice) );
+					free(aus);
+			aus = new dnnType[r->o_c];
+			for(int i=0; i < r->o_c; i++)
+					aus[i] = readBUF<dnnType>(buf);
+			checkCuda( cudaMemcpy(r->bias2_d, aus, sizeof(dnnType)*r->o_c, cudaMemcpyHostToDevice) );
+					free(aus);
+			aus = new dnnType[r->height_ones * r->width_ones];
+			for(int i=0; i<r->height_ones * r->width_ones; i++)
+					aus[i] = readBUF<dnnType>(buf);
+			checkCuda( cudaMemcpy(r->ones_d1, aus, sizeof(dnnType)*r->height_ones * r->width_ones, cudaMemcpyHostToDevice) );
+					free(aus);
+			aus = new dnnType[r->dim_ones];
+			for(int i=0; i<r->dim_ones; i++)
+					aus[i] = readBUF<dnnType>(buf);
+			checkCuda( cudaMemcpy(r->ones_d2, aus, sizeof(dnnType)*r->dim_ones, cudaMemcpyHostToDevice) );
+					free(aus);
+					assert(buf == bufCheck + serialLength);
+			return r;
+		}
+
+    void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+		}
+
+    const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+		}
+
+private:
+    static nvinfer1::PluginFieldCollection mFC;
+    static std::vector<nvinfer1::PluginField> mPluginAttributes;
+    std::string mNamespace;
+};
+}}
+#undef PLUGIN_NAME
+#undef PLUGIN_VERSION
+
+#endif // DEFORMABLE_CONV_RT_H

--- a/include/tkDNN/pluginsRT/DeformableConvRT.h
+++ b/include/tkDNN/pluginsRT/DeformableConvRT.h
@@ -185,7 +185,7 @@ public:
 
 	// Extra IPluginV2 overrides
 	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
-			return true;
+			return (type == nvinfer1::DataType::kFLOAT && format == nvinfer1::PluginFormat::kLINEAR);
 	}
 
 	nvinfer1::IPluginV2 * clone() const noexcept override {

--- a/include/tkDNN/pluginsRT/FlattenConcatRT.h
+++ b/include/tkDNN/pluginsRT/FlattenConcatRT.h
@@ -1,6 +1,20 @@
-#include<cassert>
+#ifndef FLATTEN_CONCAT_RT_H
+#define FLATTEN_CONCAT_RT_H
 
-class FlattenConcatRT : public IPlugin {
+#include <cassert>
+#include <vector>
+
+#include <NvInferRuntimeCommon.h>
+#include <NvInfer.h>
+
+#include "../kernels.h"
+#include "../buffer_func.h"
+
+#define PLUGIN_NAME "Flatten"
+#define PLUGIN_VERSION "1"
+namespace tk { namespace dnn {
+
+class FlattenConcatRT final : public nvinfer1::IPluginV2 {
 
 public:
 	FlattenConcatRT() {
@@ -11,19 +25,23 @@ public:
   		}
 	}
 
-	~FlattenConcatRT(){
+	~FlattenConcatRT() = default;
 
-	}
-
-	int getNbOutputs() const override {
+	int getNbOutputs() const noexcept override {
 		return 1;
 	}
 
-	Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) override {
-		return DimsCHW{ inputs[0].d[0] * inputs[0].d[1] * inputs[0].d[2], 1, 1};
+	nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs, int nbInputDims) noexcept override {
+		return nvinfer1::Dims3{ inputs[0].d[0] * inputs[0].d[1] * inputs[0].d[2], 1, 1};
 	}
 
-	void configure(const Dims* inputDims, int nbInputs, const Dims* outputDims, int nbOutputs, int maxBatchSize) override {
+	void configureWithFormat(nvinfer1::Dims const * inputDims,
+					int32_t nbInputs,
+					nvinfer1::Dims const * outputDims,
+					int32_t nbOutputs,
+					nvinfer1::DataType type,
+					nvinfer1::PluginFormat format,
+					int32_t maxBatchSize) noexcept override {
 		assert(nbOutputs == 1 && nbInputs ==1);
 		rows = inputDims[0].d[0];
 		cols = inputDims[0].d[1] * inputDims[0].d[2];
@@ -32,24 +50,24 @@ public:
 		w = 1;
 	}
 
-	int initialize() override {
+	int initialize() noexcept override {
 		return 0;
 	}
 
-	virtual void terminate() override {
+	void terminate() noexcept override {
 		checkERROR(cublasDestroy(handle));
 	}
 
-	virtual size_t getWorkspaceSize(int maxBatchSize) const override {
+	size_t getWorkspaceSize(int maxBatchSize) const noexcept override {
 		return 0;
 	}
 
-	virtual int enqueue(int batchSize, const void*const * inputs, void** outputs, void* workspace, cudaStream_t stream) override {
+	int enqueue(int batchSize, const void*const * inputs, void* const* outputs, void* workspace, cudaStream_t stream) noexcept override {
 		dnnType *srcData = (dnnType*)reinterpret_cast<const dnnType*>(inputs[0]);
 		dnnType *dstData = reinterpret_cast<dnnType*>(outputs[0]);
 		checkCuda( cudaMemcpyAsync(dstData, srcData, batchSize*rows*cols*sizeof(dnnType), cudaMemcpyDeviceToDevice, stream));
 
-		checkERROR( cublasSetStream(handle, stream) );	
+		checkERROR( cublasSetStream(handle, stream) );
 		for(int i=0; i<batchSize; i++) {
 			float const alpha(1.0);
 			float const beta(0.0);
@@ -59,23 +77,105 @@ public:
 		return 0;
 	}
 
-
-	virtual size_t getSerializationSize() override {
+	size_t getSerializationSize() const noexcept override {
 		return 5*sizeof(int);
 	}
 
-	virtual void serialize(void* buffer) override {
+	void serialize(void* buffer) const noexcept override {
 		char *buf = reinterpret_cast<char*>(buffer),*a = buf;
-		tk::dnn::writeBUF(buf, c);
-		tk::dnn::writeBUF(buf, h);
-		tk::dnn::writeBUF(buf, w);
-		tk::dnn::writeBUF(buf, rows);
-		tk::dnn::writeBUF(buf, cols);
+		writeBUF(buf, c);
+		writeBUF(buf, h);
+		writeBUF(buf, w);
+		writeBUF(buf, rows);
+		writeBUF(buf, cols);
 		assert(buf == a + getSerializationSize());
 	}
 
+	// Extra IPluginV2 overrides
+	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
+			return true;
+	}
+
+	nvinfer1::IPluginV2 * clone() const noexcept override {
+			auto a = new FlattenConcatRT(*this);
+			return a;
+	}
+
+	const char* getPluginType() const noexcept override {
+			return PLUGIN_NAME;
+	}
+
+	const char* getPluginVersion() const noexcept override {
+			return PLUGIN_VERSION;
+	}
+
+	void destroy() noexcept override {}
+
+	void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+	}
+
+	const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+	}
+
+	std::string mNamespace;
+
 	int c, h, w;
 	int rows, cols;
-	cublasStatus_t stat; 
-	cublasHandle_t handle; 
+	cublasStatus_t stat;
+	cublasHandle_t handle;
 };
+
+class FlattenConcatRTCreator final : public nvinfer1::IPluginCreator {
+public:
+    FlattenConcatRTCreator() = default;
+
+    const char* getPluginName() const noexcept override {
+        return PLUGIN_NAME;
+    }
+
+    const char* getPluginVersion() const noexcept override {
+        return PLUGIN_VERSION;
+    }
+
+    const nvinfer1::PluginFieldCollection* getFieldNames() noexcept override {
+        return &mFC;
+    }
+
+    nvinfer1::IPluginV2* createPlugin(const char* name, const nvinfer1::PluginFieldCollection* fc) noexcept override {
+        std::cout << "Create plugin" << std::endl;
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV2* deserializePlugin(const char* name, const void* serialData, size_t serialLength) noexcept override {
+			const char * buf = reinterpret_cast<const char*>(serialData),*bufCheck = buf;
+			float activationReluTemp = readBUF<float>(buf);
+			FlattenConcatRT *r = new FlattenConcatRT();
+			r->c = readBUF<int>(buf);
+			r->h = readBUF<int>(buf);
+			r->w = readBUF<int>(buf);
+			r->rows = readBUF<int>(buf);
+			r->cols = readBUF<int>(buf);
+			assert(buf == bufCheck + serialLength);
+			return r;
+		}
+
+    void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+		}
+
+    const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+		}
+
+private:
+    static nvinfer1::PluginFieldCollection mFC;
+    static std::vector<nvinfer1::PluginField> mPluginAttributes;
+    std::string mNamespace;
+};
+}}
+#undef PLUGIN_NAME
+#undef PLUGIN_VERSION
+
+#endif // FLATTEN_CONCAT_RT_H

--- a/include/tkDNN/pluginsRT/FlattenConcatRT.h
+++ b/include/tkDNN/pluginsRT/FlattenConcatRT.h
@@ -93,7 +93,7 @@ public:
 
 	// Extra IPluginV2 overrides
 	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
-			return true;
+			return (type == nvinfer1::DataType::kFLOAT && format == nvinfer1::PluginFormat::kLINEAR);
 	}
 
 	nvinfer1::IPluginV2 * clone() const noexcept override {

--- a/include/tkDNN/pluginsRT/MaxPoolingFixedSizeRT.h
+++ b/include/tkDNN/pluginsRT/MaxPoolingFixedSizeRT.h
@@ -86,7 +86,7 @@ public:
 
 	// Extra IPluginV2 overrides
 	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
-			return true;
+			return (type == nvinfer1::DataType::kFLOAT && format == nvinfer1::PluginFormat::kLINEAR);
 	}
 
 	nvinfer1::IPluginV2 * clone() const noexcept override {

--- a/include/tkDNN/pluginsRT/MaxPoolingFixedSizeRT.h
+++ b/include/tkDNN/pluginsRT/MaxPoolingFixedSizeRT.h
@@ -1,11 +1,24 @@
-#include<cassert>
-#include "../kernels.h"
+#ifndef MAX_POOLING_FIXED_SIZE_RT_H
+#define MAX_POOLING_FIXED_SIZE_RT_H
 
-class MaxPoolFixedSizeRT : public IPlugin {
+#include <cassert>
+#include <vector>
+
+#include <NvInferRuntimeCommon.h>
+#include <NvInfer.h>
+
+#include "../kernels.h"
+#include "../buffer_func.h"
+
+#define PLUGIN_NAME "Pooling"
+#define PLUGIN_VERSION "1"
+namespace tk { namespace dnn {
+
+class MaxPoolFixedSizeRT final : public nvinfer1::IPluginV2 {
 
 public:
 	MaxPoolFixedSizeRT(int c, int h, int w, int n, int strideH, int strideW, int winSize, int padding) {
-		this->c = c;	
+		this->c = c;
 		this->h = h;
 		this->w = w;
 		this->n = n;
@@ -15,33 +28,37 @@ public:
 		this->padding = padding;
 	}
 
-	~MaxPoolFixedSizeRT(){
-	}
+	~MaxPoolFixedSizeRT() = default;
 
-	int getNbOutputs() const override {
+	int getNbOutputs() const noexcept override {
 		return 1;
 	}
 
-	Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) override {
-		return DimsCHW{this->c, this->h, this->w};
+	nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs, int nbInputDims) noexcept override {
+		return nvinfer1::Dims3{this->c, this->h, this->w};
 	}
 
-	void configure(const Dims* inputDims, int nbInputs, const Dims* outputDims, int nbOutputs, int maxBatchSize) override {        
+	void configureWithFormat(nvinfer1::Dims const * inputDims,
+					int32_t nbInputs,
+					nvinfer1::Dims const * outputDims,
+					int32_t nbOutputs,
+					nvinfer1::DataType type,
+					nvinfer1::PluginFormat format,
+					int32_t maxBatchSize) noexcept override {
 	}
 
-	int initialize() override {
+	int initialize() noexcept override {
 		return 0;
 	}
 
-	virtual void terminate() override {
+	void terminate() noexcept override {
 	}
 
-	virtual size_t getWorkspaceSize(int maxBatchSize) const override {
+	size_t getWorkspaceSize(int maxBatchSize) const noexcept override {
 		return 0;
 	}
 
-	virtual int enqueue(int batchSize, const void*const * inputs, void** outputs, void* workspace, cudaStream_t stream) override {
-
+	int enqueue(int batchSize, const void*const * inputs, void* const* outputs, void* workspace, cudaStream_t stream) noexcept override {
 		//std::cout<<this->n<<"  "<<this->c<<"  "<<this->h<<"  "<<this->w<<"  "<<this->stride_H<<"  "<<this->stride_W<<"  "<<this->winSize<<"  "<<this->padding<<std::endl;
 		dnnType *srcData = (dnnType*)reinterpret_cast<const dnnType*>(inputs[0]);
 		dnnType *dstData = reinterpret_cast<dnnType*>(outputs[0]);
@@ -49,27 +66,112 @@ public:
 		return 0;
 	}
 
-
-	virtual size_t getSerializationSize() override {
+	size_t getSerializationSize() const noexcept override {
 		return 8*sizeof(int);
 	}
 
-	virtual void serialize(void* buffer) override {
+	void serialize(void* buffer) const noexcept override {
 		char *buf = reinterpret_cast<char*>(buffer),*a=buf;
 
-		tk::dnn::writeBUF(buf, this->c);
-		tk::dnn::writeBUF(buf, this->h);
-		tk::dnn::writeBUF(buf, this->w);
-		tk::dnn::writeBUF(buf, this->n);
-		tk::dnn::writeBUF(buf, this->stride_H);
-		tk::dnn::writeBUF(buf, this->stride_W);
-		tk::dnn::writeBUF(buf, this->winSize);
-		tk::dnn::writeBUF(buf, this->padding);
+		writeBUF(buf, this->c);
+		writeBUF(buf, this->h);
+		writeBUF(buf, this->w);
+		writeBUF(buf, this->n);
+		writeBUF(buf, this->stride_H);
+		writeBUF(buf, this->stride_W);
+		writeBUF(buf, this->winSize);
+		writeBUF(buf, this->padding);
 		assert(buf == a + getSerializationSize());
 	}
+
+	// Extra IPluginV2 overrides
+	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
+			return true;
+	}
+
+	nvinfer1::IPluginV2 * clone() const noexcept override {
+			auto a = new MaxPoolFixedSizeRT(*this);
+			return a;
+	}
+
+	const char* getPluginType() const noexcept override {
+			return PLUGIN_NAME;
+	}
+
+	const char* getPluginVersion() const noexcept override {
+			return PLUGIN_VERSION;
+	}
+
+	void destroy() noexcept override {}
+
+	void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+	}
+
+	const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+	}
+
+	std::string mNamespace;
 
 	int n, c, h, w;
 	int stride_H, stride_W;
 	int winSize;
 	int padding;
 };
+
+class MaxPoolFixedSizeRTCreator final : public nvinfer1::IPluginCreator {
+public:
+    MaxPoolFixedSizeRTCreator() = default;
+
+    const char* getPluginName() const noexcept override {
+        return PLUGIN_NAME;
+    }
+
+    const char* getPluginVersion() const noexcept override {
+        return PLUGIN_VERSION;
+    }
+
+    const nvinfer1::PluginFieldCollection* getFieldNames() noexcept override {
+        return &mFC;
+    }
+
+    nvinfer1::IPluginV2* createPlugin(const char* name, const nvinfer1::PluginFieldCollection* fc) noexcept override {
+        std::cout << "Create plugin" << std::endl;
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV2* deserializePlugin(const char* name, const void* serialData, size_t serialLength) noexcept override {
+			const char * buf = reinterpret_cast<const char*>(serialData),*bufCheck = buf;
+			int cTemp = readBUF<int>(buf);
+			int hTemp = readBUF<int>(buf);
+			int wTemp = readBUF<int>(buf);
+			int nTemp = readBUF<int>(buf);
+			int strideHTemp = readBUF<int>(buf);
+			int strideWTemp = readBUF<int>(buf);
+			int winSizeTemp = readBUF<int>(buf);
+			int paddingTemp = readBUF<int>(buf);
+
+			MaxPoolFixedSizeRT* r = new MaxPoolFixedSizeRT(cTemp, hTemp, wTemp, nTemp, strideHTemp, strideWTemp, winSizeTemp, paddingTemp);
+			assert(buf == bufCheck + serialLength);
+			return r;
+		}
+
+    void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+		}
+
+    const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+		}
+
+private:
+    static nvinfer1::PluginFieldCollection mFC;
+    static std::vector<nvinfer1::PluginField> mPluginAttributes;
+    std::string mNamespace;
+};
+}}
+#undef PLUGIN_NAME
+#undef PLUGIN_VERSION
+
+#endif // MAX_POOLING_FIXED_SIZE_RT_H

--- a/include/tkDNN/pluginsRT/RegionRT.h
+++ b/include/tkDNN/pluginsRT/RegionRT.h
@@ -1,48 +1,62 @@
-#include<cassert>
-#include "../kernels.h"
+#ifndef REGION_RT_H
+#define REGION_RT_H
 
-class RegionRT : public IPlugin {
+#include <cassert>
+#include <vector>
+
+#include <NvInferRuntimeCommon.h>
+#include <NvInfer.h>
+
+#include "../kernels.h"
+#include "../buffer_func.h"
+
+#define PLUGIN_NAME "Region"
+#define PLUGIN_VERSION "1"
+namespace tk { namespace dnn {
+
+class RegionRT final : public nvinfer1::IPluginV2 {
 
 public:
 	RegionRT(int classes, int coords, int num) {
-
 		this->classes = classes;
 		this->coords = coords;
 		this->num = num;
 	}
 
-	~RegionRT(){
+	~RegionRT() = default;
 
-	}
-
-	int getNbOutputs() const override {
+	int getNbOutputs() const noexcept override {
 		return 1;
 	}
 
-	Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) override {
+	nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs, int nbInputDims) noexcept override {
 		return inputs[0];
 	}
 
-	void configure(const Dims* inputDims, int nbInputs, const Dims* outputDims, int nbOutputs, int maxBatchSize) override {
+	void configureWithFormat(nvinfer1::Dims const * inputDims,
+					int32_t nbInputs,
+					nvinfer1::Dims const * outputDims,
+					int32_t nbOutputs,
+					nvinfer1::DataType type,
+					nvinfer1::PluginFormat format,
+					int32_t maxBatchSize) noexcept override {
 		c = inputDims[0].d[0];
 		h = inputDims[0].d[1];
 		w = inputDims[0].d[2];
 	}
 
-	int initialize() override {
-
+	int initialize() noexcept override {
 		return 0;
 	}
 
-	virtual void terminate() override {
+	void terminate() noexcept override {
 	}
 
-	virtual size_t getWorkspaceSize(int maxBatchSize) const override {
+	size_t getWorkspaceSize(int maxBatchSize) const noexcept override {
 		return 0;
 	}
 
-	virtual int enqueue(int batchSize, const void*const * inputs, void** outputs, void* workspace, cudaStream_t stream) override {
-
+	int enqueue(int batchSize, const void*const * inputs, void* const* outputs, void* workspace, cudaStream_t stream) noexcept override {
 		dnnType *srcData = (dnnType*)reinterpret_cast<const dnnType*>(inputs[0]);
 		dnnType *dstData = reinterpret_cast<dnnType*>(outputs[0]);
 
@@ -52,7 +66,7 @@ public:
 			for(int n = 0; n < num; ++n){
 				int index = entry_index(b, n*w*h, 0);
 				activationLOGISTICForward(srcData + index, dstData + index, 2*w*h, stream);
-				
+
 				index = entry_index(b, n*w*h, coords);
 				activationLOGISTICForward(srcData + index, dstData + index, w*h, stream);
 			}
@@ -60,31 +74,61 @@ public:
 
 		//softmax start
 		int index = entry_index(0, 0, coords + 1);
-		softmaxForward(	srcData + index, classes, batchSize*num, 
-						(c*h*w)/num, 
+		softmaxForward(	srcData + index, classes, batchSize*num,
+						(c*h*w)/num,
 						w*h, 1, w*h, 1, dstData + index, stream);
 
 		return 0;
 	}
 
 
-	virtual size_t getSerializationSize() override {
+	size_t getSerializationSize() const noexcept override {
 		return 6*sizeof(int);
 	}
 
-	virtual void serialize(void* buffer) override {
+	void serialize(void* buffer) const noexcept override {
 		char *buf = reinterpret_cast<char*>(buffer),*a=buf;
-		tk::dnn::writeBUF(buf, classes);
-		tk::dnn::writeBUF(buf, coords);
-		tk::dnn::writeBUF(buf, num);
-		tk::dnn::writeBUF(buf, c);
-		tk::dnn::writeBUF(buf, h);
-		tk::dnn::writeBUF(buf, w);
+		writeBUF(buf, classes);
+		writeBUF(buf, coords);
+		writeBUF(buf, num);
+		writeBUF(buf, c);
+		writeBUF(buf, h);
+		writeBUF(buf, w);
 		assert(buf == a + getSerializationSize());
 	}
 
+	// Extra IPluginV2 overrides
+	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
+			return true;
+	}
+
+	nvinfer1::IPluginV2 * clone() const noexcept override {
+			auto a = new RegionRT(*this);
+			return a;
+	}
+
+	const char* getPluginType() const noexcept override {
+			return PLUGIN_NAME;
+	}
+
+	const char* getPluginVersion() const noexcept override {
+			return PLUGIN_VERSION;
+	}
+
+	void destroy() noexcept override {}
+
+	void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+	}
+
+	const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+	}
+
+	std::string mNamespace;
+
 	int c, h, w;
-    int classes, coords, num;
+  int classes, coords, num;
 
 	int entry_index(int batch, int location, int entry) {
 		int n =   location / (w*h);
@@ -93,3 +137,57 @@ public:
 	}
 
 };
+
+class RegionRTCreator final : public nvinfer1::IPluginCreator {
+public:
+    RegionRTCreator() = default;
+
+    const char* getPluginName() const noexcept override {
+        return PLUGIN_NAME;
+    }
+
+    const char* getPluginVersion() const noexcept override {
+        return PLUGIN_VERSION;
+    }
+
+    const nvinfer1::PluginFieldCollection* getFieldNames() noexcept override {
+        return &mFC;
+    }
+
+    nvinfer1::IPluginV2* createPlugin(const char* name, const nvinfer1::PluginFieldCollection* fc) noexcept override {
+        std::cout << "Create plugin" << std::endl;
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV2* deserializePlugin(const char* name, const void* serialData, size_t serialLength) noexcept override {
+			const char * buf = reinterpret_cast<const char*>(serialData),*bufCheck = buf;
+			int classesTemp = readBUF<int>(buf);
+			int coordsTemp = readBUF<int>(buf);
+			int numTemp = readBUF<int>(buf);
+			RegionRT* r = new RegionRT(classesTemp, coordsTemp, numTemp);
+
+			r->c = readBUF<int>(buf);
+			r->h = readBUF<int>(buf);
+			r->w = readBUF<int>(buf);
+			assert(buf == bufCheck + serialLength);
+			return r;
+		}
+
+    void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+		}
+
+    const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+		}
+
+private:
+    static nvinfer1::PluginFieldCollection mFC;
+    static std::vector<nvinfer1::PluginField> mPluginAttributes;
+    std::string mNamespace;
+};
+}}
+#undef PLUGIN_NAME
+#undef PLUGIN_VERSION
+
+#endif // REGION_RT_H

--- a/include/tkDNN/pluginsRT/RegionRT.h
+++ b/include/tkDNN/pluginsRT/RegionRT.h
@@ -99,7 +99,7 @@ public:
 
 	// Extra IPluginV2 overrides
 	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
-			return true;
+			return (type == nvinfer1::DataType::kFLOAT && format == nvinfer1::PluginFormat::kLINEAR);
 	}
 
 	nvinfer1::IPluginV2 * clone() const noexcept override {

--- a/include/tkDNN/pluginsRT/ReorgRT.h
+++ b/include/tkDNN/pluginsRT/ReorgRT.h
@@ -76,7 +76,7 @@ public:
 
 	// Extra IPluginV2 overrides
 	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
-			return true;
+			return (type == nvinfer1::DataType::kFLOAT && format == nvinfer1::PluginFormat::kLINEAR);
 	}
 
 	nvinfer1::IPluginV2 * clone() const noexcept override {

--- a/include/tkDNN/pluginsRT/ReorgRT.h
+++ b/include/tkDNN/pluginsRT/ReorgRT.h
@@ -1,64 +1,159 @@
-#include<cassert>
-#include "../kernels.h"
+#ifndef REORG_RT_H
+#define REORG_RT_H
 
-class ReorgRT : public IPlugin {
+#include <cassert>
+#include <vector>
+
+#include <NvInferRuntimeCommon.h>
+#include <NvInfer.h>
+
+#include "../kernels.h"
+#include "../buffer_func.h"
+
+#define PLUGIN_NAME "Reorg"
+#define PLUGIN_VERSION "1"
+namespace tk { namespace dnn {
+
+class ReorgRT final : public nvinfer1::IPluginV2 {
 
 public:
 	ReorgRT(int stride) {
 		this->stride = stride;
 	}
 
-	~ReorgRT(){
+	~ReorgRT() = default;
 
-	}
-
-	int getNbOutputs() const override {
+	int getNbOutputs() const noexcept override {
 		return 1;
 	}
 
-	Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) override {
-		return DimsCHW{inputs[0].d[0]*stride*stride, inputs[0].d[1]/stride, inputs[0].d[2]/stride};
+	nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs, int nbInputDims) noexcept override {
+		return nvinfer1::Dims3{inputs[0].d[0]*stride*stride, inputs[0].d[1]/stride, inputs[0].d[2]/stride};
 	}
 
-	void configure(const Dims* inputDims, int nbInputs, const Dims* outputDims, int nbOutputs, int maxBatchSize) override {
+	void configureWithFormat(nvinfer1::Dims const * inputDims,
+					int32_t nbInputs,
+					nvinfer1::Dims const * outputDims,
+					int32_t nbOutputs,
+					nvinfer1::DataType type,
+					nvinfer1::PluginFormat format,
+					int32_t maxBatchSize) noexcept override {
 		c = inputDims[0].d[0];
 		h = inputDims[0].d[1];
 		w = inputDims[0].d[2];
 	}
 
-	int initialize() override {
-
+	int initialize() noexcept override {
 		return 0;
 	}
 
-	virtual void terminate() override {
+	void terminate() noexcept override {
 	}
 
-	virtual size_t getWorkspaceSize(int maxBatchSize) const override {
+	size_t getWorkspaceSize(int maxBatchSize) const noexcept override {
 		return 0;
 	}
 
-	virtual int enqueue(int batchSize, const void*const * inputs, void** outputs, void* workspace, cudaStream_t stream) override {
-
-		reorgForward((dnnType*)reinterpret_cast<const dnnType*>(inputs[0]), 
-					  reinterpret_cast<dnnType*>(outputs[0]), 
+  int32_t enqueue(int32_t batchSize, const void* const * inputs, void* const* outputs, void* workspace, cudaStream_t stream) noexcept override {
+		reorgForward((dnnType*)reinterpret_cast<const dnnType*>(inputs[0]),
+					  reinterpret_cast<dnnType*>(outputs[0]),
 					  batchSize, c, h, w, stride, stream);
 		return 0;
 	}
 
-
-	virtual size_t getSerializationSize() override {
+	size_t getSerializationSize() const noexcept override {
 		return 4*sizeof(int);
 	}
 
-	virtual void serialize(void* buffer) override {
+	void serialize(void* buffer) const noexcept override {
 		char *buf = reinterpret_cast<char*>(buffer),*a=buf;
-		tk::dnn::writeBUF(buf, stride);
-		tk::dnn::writeBUF(buf, c);
-		tk::dnn::writeBUF(buf, h);
-		tk::dnn::writeBUF(buf, w);
+		writeBUF(buf, stride);
+		writeBUF(buf, c);
+		writeBUF(buf, h);
+		writeBUF(buf, w);
 		assert(buf == a + getSerializationSize());
 	}
 
+	// Extra IPluginV2 overrides
+	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
+			return true;
+	}
+
+	nvinfer1::IPluginV2 * clone() const noexcept override {
+			auto a = new ReorgRT(*this);
+			return a;
+	}
+
+	const char* getPluginType() const noexcept override {
+			return PLUGIN_NAME;
+	}
+
+	const char* getPluginVersion() const noexcept override {
+			return PLUGIN_VERSION;
+	}
+
+	void destroy() noexcept override {}
+
+	void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+	}
+
+	const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+	}
+
+	std::string mNamespace;
+
 	int c, h, w, stride;
 };
+
+class ReorgRTCreator final : public nvinfer1::IPluginCreator {
+public:
+    ReorgRTCreator() = default;
+
+    const char* getPluginName() const noexcept override {
+        return PLUGIN_NAME;
+    }
+
+    const char* getPluginVersion() const noexcept override {
+        return PLUGIN_VERSION;
+    }
+
+    const nvinfer1::PluginFieldCollection* getFieldNames() noexcept override {
+        return &mFC;
+    }
+
+    nvinfer1::IPluginV2* createPlugin(const char* name, const nvinfer1::PluginFieldCollection* fc) noexcept override {
+        std::cout << "Create plugin" << std::endl;
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV2* deserializePlugin(const char* name, const void* serialData, size_t serialLength) noexcept override {
+			const char * buf = reinterpret_cast<const char*>(serialData),*bufCheck = buf;
+			int strideTemp = readBUF<int>(buf);
+			ReorgRT *r = new ReorgRT(strideTemp);
+			r->c = readBUF<int>(buf);
+			r->h = readBUF<int>(buf);
+			r->w = readBUF<int>(buf);
+			assert(buf == bufCheck + serialLength);
+			return r;
+		}
+
+    void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+		}
+
+    const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+		}
+
+private:
+    static nvinfer1::PluginFieldCollection mFC;
+    static std::vector<nvinfer1::PluginField> mPluginAttributes;
+    std::string mNamespace;
+};
+}}
+#undef PLUGIN_NAME
+#undef PLUGIN_VERSION
+
+#endif // REORG_RT_H

--- a/include/tkDNN/pluginsRT/ReshapeRT.h
+++ b/include/tkDNN/pluginsRT/ReshapeRT.h
@@ -78,7 +78,7 @@ public:
 
 	// Extra IPluginV2 overrides
 	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
-			return true;
+			return (type == nvinfer1::DataType::kFLOAT && format == nvinfer1::PluginFormat::kLINEAR);
 	}
 
 	nvinfer1::IPluginV2 * clone() const noexcept override {

--- a/include/tkDNN/pluginsRT/ReshapeRT.h
+++ b/include/tkDNN/pluginsRT/ReshapeRT.h
@@ -1,6 +1,21 @@
-#include<cassert>
+#ifndef RESHAPE_RT_H
+#define RESHAPE_RT_H
 
-class ReshapeRT : public IPlugin {
+#include <cassert>
+#include <vector>
+
+#include <NvInferRuntimeCommon.h>
+#include <NvInfer.h>
+
+#include "../kernels.h"
+#include "../buffer_func.h"
+#include "../Network.h"
+
+#define PLUGIN_NAME "Reshape"
+#define PLUGIN_VERSION "1"
+namespace tk { namespace dnn {
+
+class ReshapeRT final : public nvinfer1::IPluginV2 {
 
 public:
 	ReshapeRT(dataDim_t new_dim) {
@@ -10,33 +25,37 @@ public:
 		w = new_dim.w;
 	}
 
-	~ReshapeRT(){
+	~ReshapeRT() = default;
 
-	}
-
-	int getNbOutputs() const override {
+	int getNbOutputs() const noexcept override {
 		return 1;
 	}
 
-	Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) override {
-		return DimsCHW{ c,h,w};
+	nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs, int nbInputDims) noexcept override {
+		return nvinfer1::Dims3{ c,h,w};
 	}
 
-	void configure(const Dims* inputDims, int nbInputs, const Dims* outputDims, int nbOutputs, int maxBatchSize) override {
+	void configureWithFormat(nvinfer1::Dims const * inputDims,
+					int32_t nbInputs,
+					nvinfer1::Dims const * outputDims,
+					int32_t nbOutputs,
+					nvinfer1::DataType type,
+					nvinfer1::PluginFormat format,
+					int32_t maxBatchSize) noexcept override {
 	}
 
-	int initialize() override {
+	int initialize() noexcept override {
 		return 0;
 	}
 
-	virtual void terminate() override {
+	virtual void terminate() noexcept override {
 	}
 
-	virtual size_t getWorkspaceSize(int maxBatchSize) const override {
+	virtual size_t getWorkspaceSize(int maxBatchSize) const noexcept override {
 		return 0;
 	}
 
-	virtual int enqueue(int batchSize, const void*const * inputs, void** outputs, void* workspace, cudaStream_t stream) override {
+	virtual int enqueue(int batchSize, const void*const * inputs, void* const* outputs, void* workspace, cudaStream_t stream) noexcept override {
 		dnnType *srcData = (dnnType*)reinterpret_cast<const dnnType*>(inputs[0]);
 		dnnType *dstData = reinterpret_cast<dnnType*>(outputs[0]);
 
@@ -44,19 +63,100 @@ public:
 		return 0;
 	}
 
-
-	virtual size_t getSerializationSize() override {
+	virtual size_t getSerializationSize() const noexcept override {
 		return 4*sizeof(int);
 	}
 
-	virtual void serialize(void* buffer) override {
+	virtual void serialize(void* buffer) const noexcept override {
 		char *buf = reinterpret_cast<char*>(buffer),*a = buf;
-		tk::dnn::writeBUF(buf, n);
-		tk::dnn::writeBUF(buf, c);
-		tk::dnn::writeBUF(buf, h);
-		tk::dnn::writeBUF(buf, w);
+		writeBUF(buf, n);
+		writeBUF(buf, c);
+		writeBUF(buf, h);
+		writeBUF(buf, w);
 		assert(buf == a + getSerializationSize());
 	}
 
+	// Extra IPluginV2 overrides
+	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
+			return true;
+	}
+
+	nvinfer1::IPluginV2 * clone() const noexcept override {
+			auto a = new ReshapeRT(*this);
+			return a;
+	}
+
+	const char* getPluginType() const noexcept override {
+			return PLUGIN_NAME;
+	}
+
+	const char* getPluginVersion() const noexcept override {
+			return PLUGIN_VERSION;
+	}
+
+	void destroy() noexcept override {}
+
+	void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+	}
+
+	const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+	}
+
+	std::string mNamespace;
 	int n, c, h, w;
 };
+
+class ReshapeRTCreator final : public nvinfer1::IPluginCreator {
+public:
+    ReshapeRTCreator() = default;
+
+    const char* getPluginName() const noexcept override {
+        return PLUGIN_NAME;
+    }
+
+    const char* getPluginVersion() const noexcept override {
+        return PLUGIN_VERSION;
+    }
+
+    const nvinfer1::PluginFieldCollection* getFieldNames() noexcept override {
+        return &mFC;
+    }
+
+    nvinfer1::IPluginV2* createPlugin(const char* name, const nvinfer1::PluginFieldCollection* fc) noexcept override {
+        std::cout << "Create plugin" << std::endl;
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV2* deserializePlugin(const char* name, const void* serialData, size_t serialLength) noexcept override {
+			const char * buf = reinterpret_cast<const char*>(serialData),*bufCheck = buf;
+			dataDim_t new_dim;
+			new_dim.n = readBUF<int>(buf);
+			new_dim.c = readBUF<int>(buf);
+			new_dim.h = readBUF<int>(buf);
+			new_dim.w = readBUF<int>(buf);
+			ReshapeRT *r = new ReshapeRT(new_dim);
+			assert(buf == bufCheck + serialLength);
+
+			return r;
+		}
+
+    void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+		}
+
+    const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+		}
+
+private:
+    static nvinfer1::PluginFieldCollection mFC;
+    static std::vector<nvinfer1::PluginField> mPluginAttributes;
+    std::string mNamespace;
+};
+}}
+#undef PLUGIN_NAME
+#undef PLUGIN_VERSION
+
+#endif // RESHAPE_RT_H

--- a/include/tkDNN/pluginsRT/ResizeLayerRT.h
+++ b/include/tkDNN/pluginsRT/ResizeLayerRT.h
@@ -83,7 +83,7 @@ public:
 
 	// Extra IPluginV2 overrides
 	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
-			return true;
+			return (type == nvinfer1::DataType::kFLOAT && format == nvinfer1::PluginFormat::kLINEAR);
 	}
 
 	nvinfer1::IPluginV2 * clone() const noexcept override {

--- a/include/tkDNN/pluginsRT/ResizeLayerRT.h
+++ b/include/tkDNN/pluginsRT/ResizeLayerRT.h
@@ -1,68 +1,168 @@
-#include<cassert>
-#include "../kernels.h"
+#ifndef RESIZE_LAYER_RT_H
+#define RESIZE_LAYER_RT_H
 
-class ResizeLayerRT : public IPlugin {
+#include <cassert>
+#include <vector>
+
+#include <NvInferRuntimeCommon.h>
+#include <NvInfer.h>
+
+#include "../kernels.h"
+#include "../buffer_func.h"
+
+#define PLUGIN_NAME "Resize"
+#define PLUGIN_VERSION "1"
+namespace tk { namespace dnn {
+
+class ResizeLayerRT final : public nvinfer1::IPluginV2 {
 
 public:
 	ResizeLayerRT(int c, int h, int w) {
 		o_c = c;
 		o_h = h;
-		o_w = w;	
+		o_w = w;
 	}
 
-	~ResizeLayerRT(){
-	}
+	~ResizeLayerRT() = default;
 
-	int getNbOutputs() const override {
+	int getNbOutputs() const noexcept override {
 		return 1;
 	}
 
-	Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) override {
-		return DimsCHW{o_c, o_h, o_w};
+	nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs, int nbInputDims) noexcept override {
+		return nvinfer1::Dims3{o_c, o_h, o_w};
 	}
 
-	void configure(const Dims* inputDims, int nbInputs, const Dims* outputDims, int nbOutputs, int maxBatchSize) override {
+	void configureWithFormat(nvinfer1::Dims const * inputDims,
+					int32_t nbInputs,
+					nvinfer1::Dims const * outputDims,
+					int32_t nbOutputs,
+					nvinfer1::DataType type,
+					nvinfer1::PluginFormat format,
+					int32_t maxBatchSize) noexcept override {
 		i_c = inputDims[0].d[0];
 		i_h = inputDims[0].d[1];
-		i_w = inputDims[0].d[2];        
+		i_w = inputDims[0].d[2];
 	}
 
-	int initialize() override {
+	int initialize() noexcept override {
 		return 0;
 	}
 
-	virtual void terminate() override {
+	void terminate() noexcept override {
 	}
 
-	virtual size_t getWorkspaceSize(int maxBatchSize) const override {
+	size_t getWorkspaceSize(int maxBatchSize) const noexcept override {
 		return 0;
 	}
 
-	virtual int enqueue(int batchSize, const void*const * inputs, void** outputs, void* workspace, cudaStream_t stream) override {
+	int enqueue(int batchSize, const void*const * inputs, void* const* outputs, void* workspace, cudaStream_t stream) noexcept override {
     	// printf("%d %d %d %d %d %d\n", i_c, i_w, i_h, o_c, o_w, o_h);
-        resizeForward((dnnType*)reinterpret_cast<const dnnType*>(inputs[0]), 
-					  reinterpret_cast<dnnType*>(outputs[0]), 
+        resizeForward((dnnType*)reinterpret_cast<const dnnType*>(inputs[0]),
+					  reinterpret_cast<dnnType*>(outputs[0]),
 					  batchSize, i_c, i_h, i_w, o_c, o_h, o_w, stream);
 		return 0;
 	}
 
-
-	virtual size_t getSerializationSize() override {
+	size_t getSerializationSize() const noexcept override {
 		return 6*sizeof(int);
 	}
 
-	virtual void serialize(void* buffer) override {
+	void serialize(void* buffer) const noexcept override {
 		char *buf = reinterpret_cast<char*>(buffer),*a=buf;
 
-		tk::dnn::writeBUF(buf, o_c);
-		tk::dnn::writeBUF(buf, o_h);
-		tk::dnn::writeBUF(buf, o_w);
+		writeBUF(buf, o_c);
+		writeBUF(buf, o_h);
+		writeBUF(buf, o_w);
 
-		tk::dnn::writeBUF(buf, i_c);
-		tk::dnn::writeBUF(buf, i_h);
-		tk::dnn::writeBUF(buf, i_w);
+		writeBUF(buf, i_c);
+		writeBUF(buf, i_h);
+		writeBUF(buf, i_w);
 		assert(buf == a + getSerializationSize());
 	}
 
+	// Extra IPluginV2 overrides
+	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
+			return true;
+	}
+
+	nvinfer1::IPluginV2 * clone() const noexcept override {
+			auto a = new ResizeLayerRT(*this);
+			return a;
+	}
+
+	const char* getPluginType() const noexcept override {
+			return PLUGIN_NAME;
+	}
+
+	const char* getPluginVersion() const noexcept override {
+			return PLUGIN_VERSION;
+	}
+
+	void destroy() noexcept override {}
+
+	void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+	}
+
+	const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+	}
+
+	std::string mNamespace;
 	int i_c, i_h, i_w, o_c, o_h, o_w;
 };
+
+class ResizeLayerRTCreator final : public nvinfer1::IPluginCreator {
+public:
+    ResizeLayerRTCreator() = default;
+
+    const char* getPluginName() const noexcept override {
+        return PLUGIN_NAME;
+    }
+
+    const char* getPluginVersion() const noexcept override {
+        return PLUGIN_VERSION;
+    }
+
+    const nvinfer1::PluginFieldCollection* getFieldNames() noexcept override {
+        return &mFC;
+    }
+
+    nvinfer1::IPluginV2* createPlugin(const char* name, const nvinfer1::PluginFieldCollection* fc) noexcept override {
+        std::cout << "Create plugin" << std::endl;
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV2* deserializePlugin(const char* name, const void* serialData, size_t serialLength) noexcept override {
+			const char * buf = reinterpret_cast<const char*>(serialData),*bufCheck = buf;
+			int o_cTemp = readBUF<int>(buf);
+			int o_hTemp = readBUF<int>(buf);
+			int o_wTemp = readBUF<int>(buf);
+			ResizeLayerRT* r = new ResizeLayerRT(o_cTemp, o_hTemp, o_wTemp);
+
+			r->i_c = readBUF<int>(buf);
+			r->i_h = readBUF<int>(buf);
+			r->i_w = readBUF<int>(buf);
+			assert(buf == bufCheck + serialLength);
+			return r;
+		}
+
+    void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+		}
+
+    const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+		}
+
+private:
+    static nvinfer1::PluginFieldCollection mFC;
+    static std::vector<nvinfer1::PluginField> mPluginAttributes;
+    std::string mNamespace;
+};
+}}
+#undef PLUGIN_NAME
+#undef PLUGIN_VERSION
+
+#endif // RESIZE_LAYER_RT_H

--- a/include/tkDNN/pluginsRT/RouteRT.h
+++ b/include/tkDNN/pluginsRT/RouteRT.h
@@ -105,7 +105,7 @@ public:
 
 	// Extra IPluginV2 overrides
 	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
-			return true;
+			return (type == nvinfer1::DataType::kFLOAT && format == nvinfer1::PluginFormat::kLINEAR);
 	}
 
 	nvinfer1::IPluginV2 * clone() const noexcept override {

--- a/include/tkDNN/pluginsRT/ShortcutRT.h
+++ b/include/tkDNN/pluginsRT/ShortcutRT.h
@@ -1,48 +1,64 @@
-#include<cassert>
-#include "../kernels.h"
+#ifndef SHORTCUT_RT_H
+#define SHORTCUT_RT_H
 
-class ShortcutRT : public IPlugin {
+#include <cassert>
+#include <vector>
+
+#include <NvInferRuntimeCommon.h>
+#include <NvInfer.h>
+
+#include "../kernels.h"
+#include "../buffer_func.h"
+#include "../Network.h"
+
+#define PLUGIN_NAME "Shortcut"
+#define PLUGIN_VERSION "1"
+namespace tk { namespace dnn {
+
+class ShortcutRT final : public nvinfer1::IPluginV2 {
 
 public:
-	ShortcutRT(tk::dnn::dataDim_t bdim, bool mul) {
+	ShortcutRT(dataDim_t bdim, bool mul) {
 		this->bc = bdim.c;
 		this->bh = bdim.h;
 		this->bw = bdim.w;
 		this->mul = mul;
 	}
 
-	~ShortcutRT(){
+	~ShortcutRT() = default;
 
-	}
-
-	int getNbOutputs() const override {
+	int getNbOutputs() const noexcept override {
 		return 1;
 	}
 
-	Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) override {
-		return DimsCHW{inputs[0].d[0], inputs[0].d[1], inputs[0].d[2]};
+	nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs, int nbInputDims) noexcept override {
+		return nvinfer1::Dims3{inputs[0].d[0], inputs[0].d[1], inputs[0].d[2]};
 	}
 
-	void configure(const Dims* inputDims, int nbInputs, const Dims* outputDims, int nbOutputs, int maxBatchSize) override {
+	void configureWithFormat(nvinfer1::Dims const * inputDims,
+					int32_t nbInputs,
+					nvinfer1::Dims const * outputDims,
+					int32_t nbOutputs,
+					nvinfer1::DataType type,
+					nvinfer1::PluginFormat format,
+					int32_t maxBatchSize) noexcept override {
 		c = inputDims[0].d[0];
 		h = inputDims[0].d[1];
 		w = inputDims[0].d[2];
 	}
 
-	int initialize() override {
-
+	int initialize() noexcept override {
 		return 0;
 	}
 
-	virtual void terminate() override {
+	void terminate() noexcept override {
 	}
 
-	virtual size_t getWorkspaceSize(int maxBatchSize) const override {
+	size_t getWorkspaceSize(int maxBatchSize) const noexcept override {
 		return 0;
 	}
 
-	virtual int enqueue(int batchSize, const void*const * inputs, void** outputs, void* workspace, cudaStream_t stream) override {
-
+	int enqueue(int batchSize, const void*const * inputs, void* const* outputs, void* workspace, cudaStream_t stream) noexcept override {
 		dnnType *srcData = (dnnType*)reinterpret_cast<const dnnType*>(inputs[0]);
 		dnnType *srcDataBack = (dnnType*)reinterpret_cast<const dnnType*>(inputs[1]);
 		dnnType *dstData = reinterpret_cast<dnnType*>(outputs[0]);
@@ -54,24 +70,110 @@ public:
 	}
 
 
-	virtual size_t getSerializationSize() override {
+	size_t getSerializationSize() const noexcept override {
 		return 6*sizeof(int) + sizeof(bool);
 	}
 
-	virtual void serialize(void* buffer) override {
+	void serialize(void* buffer) const noexcept override {
 		char *buf = reinterpret_cast<char*>(buffer),*a=buf;
-		tk::dnn::writeBUF(buf, bc);
-		tk::dnn::writeBUF(buf, bh);
-		tk::dnn::writeBUF(buf, bw);
-		tk::dnn::writeBUF(buf, mul);
-		tk::dnn::writeBUF(buf, c);
-		tk::dnn::writeBUF(buf, h);
-		tk::dnn::writeBUF(buf, w);
+		writeBUF(buf, bc);
+		writeBUF(buf, bh);
+		writeBUF(buf, bw);
+		writeBUF(buf, mul);
+		writeBUF(buf, c);
+		writeBUF(buf, h);
+		writeBUF(buf, w);
 		assert(buf == a + getSerializationSize());
-		
+
 	}
+
+	// Extra IPluginV2 overrides
+	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
+			return true;
+	}
+
+	nvinfer1::IPluginV2 * clone() const noexcept override {
+			auto a = new ShortcutRT(*this);
+			return a;
+	}
+
+	const char* getPluginType() const noexcept override {
+			return PLUGIN_NAME;
+	}
+
+	const char* getPluginVersion() const noexcept override {
+			return PLUGIN_VERSION;
+	}
+
+	void destroy() noexcept override {}
+
+	void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+	}
+
+	const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+	}
+
+	std::string mNamespace;
 
 	int c, h, w;
 	int bc, bh, bw;
 	bool mul;
 };
+
+class ShortcutRTCreator final : public nvinfer1::IPluginCreator {
+public:
+    ShortcutRTCreator() = default;
+
+    const char* getPluginName() const noexcept override {
+        return PLUGIN_NAME;
+    }
+
+    const char* getPluginVersion() const noexcept override {
+        return PLUGIN_VERSION;
+    }
+
+    const nvinfer1::PluginFieldCollection* getFieldNames() noexcept override {
+        return &mFC;
+    }
+
+    nvinfer1::IPluginV2* createPlugin(const char* name, const nvinfer1::PluginFieldCollection* fc) noexcept override {
+        std::cout << "Create plugin" << std::endl;
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV2* deserializePlugin(const char* name, const void* serialData, size_t serialLength) noexcept override {
+			const char * buf = reinterpret_cast<const char*>(serialData),*bufCheck = buf;
+			dataDim_t bdim;
+			bdim.c = readBUF<int>(buf);
+			bdim.h = readBUF<int>(buf);
+			bdim.w = readBUF<int>(buf);
+			bdim.l = 1;
+
+			ShortcutRT *r = new ShortcutRT(bdim, readBUF<bool>(buf));
+			r->c = readBUF<int>(buf);
+			r->h = readBUF<int>(buf);
+			r->w = readBUF<int>(buf);
+			assert(buf == bufCheck + serialLength);
+			return r;
+		}
+
+    void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+		}
+
+    const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+		}
+
+private:
+    static nvinfer1::PluginFieldCollection mFC;
+    static std::vector<nvinfer1::PluginField> mPluginAttributes;
+    std::string mNamespace;
+};
+}}
+#undef PLUGIN_NAME
+#undef PLUGIN_VERSION
+
+#endif // SHORTCUT_RT_H

--- a/include/tkDNN/pluginsRT/ShortcutRT.h
+++ b/include/tkDNN/pluginsRT/ShortcutRT.h
@@ -89,7 +89,7 @@ public:
 
 	// Extra IPluginV2 overrides
 	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
-			return true;
+			return (type == nvinfer1::DataType::kFLOAT && format == nvinfer1::PluginFormat::kLINEAR);
 	}
 
 	nvinfer1::IPluginV2 * clone() const noexcept override {

--- a/include/tkDNN/pluginsRT/UpsampleRT.h
+++ b/include/tkDNN/pluginsRT/UpsampleRT.h
@@ -1,66 +1,160 @@
-#include<cassert>
-#include "../kernels.h"
+#ifndef UPSAMPLE_RT_H
+#define UPSAMPLE_RT_H
 
-class UpsampleRT : public IPlugin {
+#include <cassert>
+#include <vector>
+
+#include <NvInferRuntimeCommon.h>
+#include <NvInfer.h>
+
+#include "../kernels.h"
+#include "../buffer_func.h"
+
+#define PLUGIN_NAME "Upsample"
+#define PLUGIN_VERSION "1"
+namespace tk { namespace dnn {
+
+class UpsampleRT final : public nvinfer1::IPluginV2 {
 
 public:
 	UpsampleRT(int stride) {
 		this->stride = stride;
 	}
 
-	~UpsampleRT(){
+	~UpsampleRT() = default;
 
-	}
-
-	int getNbOutputs() const override {
+	int getNbOutputs() const noexcept override {
 		return 1;
 	}
 
-	Dims getOutputDimensions(int index, const Dims* inputs, int nbInputDims) override {
-		return DimsCHW(inputs[0].d[0], inputs[0].d[1]*stride, inputs[0].d[2]*stride);
+	nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs, int nbInputDims) noexcept override {
+		return nvinfer1::Dims3(inputs[0].d[0], inputs[0].d[1]*stride, inputs[0].d[2]*stride);
 	}
 
-	void configure(const Dims* inputDims, int nbInputs, const Dims* outputDims, int nbOutputs, int maxBatchSize) override {
+	void configureWithFormat(nvinfer1::Dims const * inputDims,
+					int32_t nbInputs,
+					nvinfer1::Dims const * outputDims,
+					int32_t nbOutputs,
+					nvinfer1::DataType type,
+					nvinfer1::PluginFormat format,
+					int32_t maxBatchSize) noexcept override {
 		c = inputDims[0].d[0];
 		h = inputDims[0].d[1];
 		w = inputDims[0].d[2];
 	}
 
-	int initialize() override {
-
+	int initialize() noexcept override {
 		return 0;
 	}
 
-	virtual void terminate() override {
+	void terminate() noexcept override {
 	}
 
-	virtual size_t getWorkspaceSize(int maxBatchSize) const override {
+	size_t getWorkspaceSize(int maxBatchSize) const noexcept override {
 		return 0;
 	}
 
-	virtual int enqueue(int batchSize, const void*const * inputs, void** outputs, void* workspace, cudaStream_t stream) override {
-
+	int enqueue(int batchSize, const void*const * inputs, void* const* outputs, void* workspace, cudaStream_t stream) noexcept override {
 		dnnType *srcData = (dnnType*)reinterpret_cast<const dnnType*>(inputs[0]);
 		dnnType *dstData = reinterpret_cast<dnnType*>(outputs[0]);
-	    
+
 		fill(dstData, batchSize*c*h*w*stride*stride, 0.0, stream);
     	upsampleForward(srcData, dstData, batchSize, c, h, w, stride, 1, 1, stream);
 		return 0;
 	}
 
-
-	virtual size_t getSerializationSize() override {
+	size_t getSerializationSize() const noexcept override {
 		return 4*sizeof(int);
 	}
 
-	virtual void serialize(void* buffer) override {
+	void serialize(void* buffer) const noexcept override {
 		char *buf = reinterpret_cast<char*>(buffer),*a=buf;
-		tk::dnn::writeBUF(buf, stride);
-		tk::dnn::writeBUF(buf, c);
-		tk::dnn::writeBUF(buf, h);
-		tk::dnn::writeBUF(buf, w);
+		writeBUF(buf, stride);
+		writeBUF(buf, c);
+		writeBUF(buf, h);
+		writeBUF(buf, w);
 		assert(buf == a + getSerializationSize());
 	}
 
+	// Extra IPluginV2 overrides
+	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
+			return true;
+	}
+
+	nvinfer1::IPluginV2 * clone() const noexcept override {
+			auto a = new UpsampleRT(*this);
+			return a;
+	}
+
+	const char* getPluginType() const noexcept override {
+			return PLUGIN_NAME;
+	}
+
+	const char* getPluginVersion() const noexcept override {
+			return PLUGIN_VERSION;
+	}
+
+	void destroy() noexcept override {}
+
+	void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+	}
+
+	const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+	}
+
+	std::string mNamespace;
 	int c, h, w, stride;
 };
+
+class UpsampleRTCreator final : public nvinfer1::IPluginCreator {
+public:
+    UpsampleRTCreator() = default;
+
+    const char* getPluginName() const noexcept override {
+        return PLUGIN_NAME;
+    }
+
+    const char* getPluginVersion() const noexcept override {
+        return PLUGIN_VERSION;
+    }
+
+    const nvinfer1::PluginFieldCollection* getFieldNames() noexcept override {
+        return &mFC;
+    }
+
+    nvinfer1::IPluginV2* createPlugin(const char* name, const nvinfer1::PluginFieldCollection* fc) noexcept override {
+        std::cout << "Create plugin" << std::endl;
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV2* deserializePlugin(const char* name, const void* serialData, size_t serialLength) noexcept override {
+			const char * buf = reinterpret_cast<const char*>(serialData),*bufCheck = buf;
+			int strideTemp = readBUF<int>(buf);
+			UpsampleRT* r = new UpsampleRT(strideTemp);
+			r->c = readBUF<int>(buf);
+			r->h = readBUF<int>(buf);
+			r->w = readBUF<int>(buf);
+			assert(buf == bufCheck + serialLength);
+			return r;
+		}
+
+    void setPluginNamespace(const char* pluginNamespace) noexcept override {
+			mNamespace = pluginNamespace;
+		}
+
+    const char* getPluginNamespace() const noexcept override {
+			return mNamespace.c_str();
+		}
+
+private:
+    static nvinfer1::PluginFieldCollection mFC;
+    static std::vector<nvinfer1::PluginField> mPluginAttributes;
+    std::string mNamespace;
+};
+}}
+#undef PLUGIN_NAME
+#undef PLUGIN_VERSION
+
+#endif // UPSAMPLE_RT_H

--- a/include/tkDNN/pluginsRT/UpsampleRT.h
+++ b/include/tkDNN/pluginsRT/UpsampleRT.h
@@ -78,7 +78,7 @@ public:
 
 	// Extra IPluginV2 overrides
 	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
-			return true;
+			return (type == nvinfer1::DataType::kFLOAT && format == nvinfer1::PluginFormat::kLINEAR);
 	}
 
 	nvinfer1::IPluginV2 * clone() const noexcept override {

--- a/include/tkDNN/pluginsRT/YoloRT.h
+++ b/include/tkDNN/pluginsRT/YoloRT.h
@@ -137,7 +137,7 @@ public:
 
 	// Extra IPluginV2 overrides
 	bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format) const noexcept override {
-			return true;
+			return (type == nvinfer1::DataType::kFLOAT && format == nvinfer1::PluginFormat::kLINEAR);
 	}
 
 	nvinfer1::IPluginV2 * clone() const noexcept override {

--- a/include/tkDNN/yoloContainer.h
+++ b/include/tkDNN/yoloContainer.h
@@ -1,0 +1,16 @@
+#ifndef YOLO_CONTAINER_H
+#define YOLO_CONTAINER_H
+
+namespace tk { namespace dnn {
+class YoloRT;
+class YoloContainer
+{
+public:
+    YoloRT *yolos[16];
+    int n_yolos{};
+};
+
+extern YoloContainer yoloContainer;
+}}
+
+#endif // YOLO_CONTAINER_H

--- a/src/Int8Calibrator.cpp
+++ b/src/Int8Calibrator.cpp
@@ -1,20 +1,20 @@
 #include "Int8Calibrator.h"
 
-Int8EntropyCalibrator::Int8EntropyCalibrator(BatchStream& stream, int firstBatch, 
+Int8EntropyCalibrator::Int8EntropyCalibrator(BatchStream& stream, int firstBatch,
                                              const std::string& calibTableFilePath,
                                              const std::string& inputBlobName,
-                                             bool readCache): 
-    mStream(stream), 
+                                             bool readCache):
+    mStream(stream),
     mCalibTableFilePath(calibTableFilePath),
     mInputBlobName(inputBlobName.c_str()),
     mReadCache(readCache) {
-    nvinfer1::DimsNCHW dims = mStream.getDims();
-    mInputCount = mStream.getBatchSize() * dims.c() * dims.h() * dims.w();
+    nvinfer1::Dims4 dims = mStream.getDims();
+    mInputCount = mStream.getBatchSize() * dims.d[1] * dims.d[2] * dims.d[3];
     checkCuda(cudaMalloc(&mDeviceInput, mInputCount * sizeof(float)));
     mStream.reset(firstBatch);
 }
 
-bool Int8EntropyCalibrator::getBatch(void* bindings[], const char* names[], int nbBindings) {
+bool Int8EntropyCalibrator::getBatch(void* bindings[], const char* names[], int nbBindings) noexcept {
     if (!mStream.next())
         return false;
 
@@ -24,7 +24,7 @@ bool Int8EntropyCalibrator::getBatch(void* bindings[], const char* names[], int 
     return true;
 }
 
-const void* Int8EntropyCalibrator::readCalibrationCache(size_t& length) {
+const void* Int8EntropyCalibrator::readCalibrationCache(size_t& length) noexcept {
     mCalibrationCache.clear();
     assert(!mCalibTableFilePath.empty());
     std::ifstream input(mCalibTableFilePath, std::ios::binary);
@@ -38,7 +38,7 @@ const void* Int8EntropyCalibrator::readCalibrationCache(size_t& length) {
     return length ? &mCalibrationCache[0] : nullptr;
 }
 
-void Int8EntropyCalibrator::writeCalibrationCache(const void* cache, size_t length) {
+void Int8EntropyCalibrator::writeCalibrationCache(const void* cache, size_t length) noexcept {
     assert(!mCalibTableFilePath.empty());
     std::ofstream output(mCalibTableFilePath, std::ios::binary);
     output.write(reinterpret_cast<const char*>(cache), length);

--- a/src/kernels/activation_leaky.cu
+++ b/src/kernels/activation_leaky.cu
@@ -5,7 +5,7 @@ void activation_leaky(dnnType *input, dnnType *output, int size, float slope) {
 
     int i = blockDim.x*blockIdx.x + threadIdx.x;
 
-    if(i<size) {    
+    if(i<size) {
         if (input[i]>0)
             output[i] = input[i];
         else
@@ -21,7 +21,7 @@ void activationLEAKYForward(dnnType* srcData, dnnType* dstData, int size, float 
 {
     int blocks = (size+255)/256;
     int threads = 256;
-    
+
     activation_leaky<<<blocks, threads, 0, stream>>>(srcData, dstData, size, slope);
 }
 

--- a/src/kernels/activation_logistic.cu
+++ b/src/kernels/activation_logistic.cu
@@ -1,11 +1,22 @@
+#include <vector>
+
 #include "kernels.h"
+#include "pluginsRT/ActivationLogisticRT.h"
+
+// Static class fields initialization
+namespace tk { namespace dnn {
+nvinfer1::PluginFieldCollection ActivationLogisticRTCreator::mFC{};
+std::vector<nvinfer1::PluginField> ActivationLogisticRTCreator::mPluginAttributes;
+
+REGISTER_TENSORRT_PLUGIN(ActivationLogisticRTCreator);
+}}
 
 __global__
 void activation_logistic(dnnType *input, dnnType *output, int size) {
 
     int i = blockDim.x*blockIdx.x + threadIdx.x;
 
-    if(i<size) {    
+    if(i<size) {
         output[i] =  1.0f/(1.0f + exp(-input[i]));;
     }
  }
@@ -18,8 +29,6 @@ void activationLOGISTICForward(dnnType* srcData, dnnType* dstData, int size, cud
 {
     int blocks = (size+255)/256;
     int threads = 256;
-    
+
     activation_logistic<<<blocks, threads, 0, stream>>>(srcData, dstData, size);
 }
-
-

--- a/src/kernels/activation_mish.cu
+++ b/src/kernels/activation_mish.cu
@@ -1,40 +1,47 @@
-#include "kernels.h"
 #include <math.h>
+#include "kernels.h"
+#include "pluginsRT/ActivationMishRT.h"
 
 #define MISH_THRESHOLD 20
 
-__device__ 
+// Static class fields initialization
+namespace tk { namespace dnn {
+nvinfer1::PluginFieldCollection ActivationMishRTCreator::mFC{};
+std::vector<nvinfer1::PluginField> ActivationMishRTCreator::mPluginAttributes;
+
+REGISTER_TENSORRT_PLUGIN(ActivationMishRTCreator);
+}}
+
+__device__
 float tanh_activate_kernel(float x){return (2/(1 + expf(-2*x)) - 1);}
 
-__device__ 
+__device__
 float softplus_kernel(float x, float threshold = 20) {
     if (x > threshold) return x;                // too large
     else if (x < -threshold) return expf(x);    // too small
     return logf(expf(x) + 1);
 }
 
+__device__
+float mish_yashas(float x) {
+    float e = __expf(x);
+    if (x <= -18.0f)
+        return x * e;
 
+    float n = e * e + 2 * e;
+    if (x <= -5.0f)
+        return x * __fdividef(n, n + 2);
 
-__device__ 
-float mish_yashas(float x) { 
-    float e = __expf(x); 
-    if (x <= -18.0f) 
-        return x * e; 
- 
-    float n = e * e + 2 * e; 
-    if (x <= -5.0f) 
-        return x * __fdividef(n, n + 2); 
- 
-    return x - 2 * __fdividef(x, n + 2); 
-} 
+    return x - 2 * __fdividef(x, n + 2);
+}
 
 // https://github.com/digantamisra98/Mish
 // https://github.com/AlexeyAB/darknet/blob/master/src/activation_kernels.cu
 __global__
 void activation_mish(dnnType *input, dnnType *output, int size) {
     int i = (blockIdx.x + blockIdx.y*gridDim.x) * blockDim.x + threadIdx.x;
-    if (i < size) 
-        // output[i] = input[i] * tanh_activate_kernel( softplus_kernel(input[i], MISH_THRESHOLD));    
+    if (i < size)
+        // output[i] = input[i] * tanh_activate_kernel( softplus_kernel(input[i], MISH_THRESHOLD));
         output[i] = mish_yashas(input[i]);
 }
 
@@ -45,6 +52,6 @@ void activationMishForward(dnnType* srcData, dnnType* dstData, int size, cudaStr
 {
     int blocks = (size+255)/256;
     int threads = 256;
-    
+
     activation_mish<<<blocks, threads, 0, stream>>>(srcData, dstData, size);
 }

--- a/src/kernels/activation_mish.cu
+++ b/src/kernels/activation_mish.cu
@@ -35,6 +35,16 @@ float mish_yashas(float x) {
     return x - 2 * __fdividef(x, n + 2);
 }
 
+__device__ float mish_yashas2(float x)
+{
+    float e = __expf(x);
+    float n = e * e + 2 * e;
+    if (x <= -0.6f)
+        return x * __fdividef(n, n + 2);
+
+    return x - 2 * __fdividef(x, n + 2);
+}
+
 // https://github.com/digantamisra98/Mish
 // https://github.com/AlexeyAB/darknet/blob/master/src/activation_kernels.cu
 __global__
@@ -42,7 +52,7 @@ void activation_mish(dnnType *input, dnnType *output, int size) {
     int i = (blockIdx.x + blockIdx.y*gridDim.x) * blockDim.x + threadIdx.x;
     if (i < size)
         // output[i] = input[i] * tanh_activate_kernel( softplus_kernel(input[i], MISH_THRESHOLD));
-        output[i] = mish_yashas(input[i]);
+        output[i] = mish_yashas2(input[i]);
 }
 
 /**

--- a/src/kernels/activation_relu_ceiling.cu
+++ b/src/kernels/activation_relu_ceiling.cu
@@ -1,11 +1,20 @@
 #include "kernels.h"
+#include "pluginsRT/ActivationReLUCeilingRT.h"
+
+// Static class fields initialization
+namespace tk { namespace dnn {
+nvinfer1::PluginFieldCollection ActivationReLUCeilingCreator::mFC{};
+std::vector<nvinfer1::PluginField> ActivationReLUCeilingCreator::mPluginAttributes;
+
+REGISTER_TENSORRT_PLUGIN(ActivationReLUCeilingCreator);
+}}
 
 __global__
 void activation_relu_ceiling(dnnType *input, dnnType *output, int size, const float ceiling) {
 
     int i = blockDim.x*blockIdx.x + threadIdx.x;
 
-    if(i<size) {    
+    if(i<size) {
         if (input[i]>0)
         {
             if (input[i]>ceiling)
@@ -26,7 +35,7 @@ void activationReLUCeilingForward(dnnType* srcData, dnnType* dstData, int size, 
 {
     int blocks = (size+255)/256;
     int threads = 256;
-    
+
     activation_relu_ceiling<<<blocks, threads, 0, stream>>>(srcData, dstData, size, ceiling);
 }
 

--- a/src/kernels/activation_sigmoid.cu
+++ b/src/kernels/activation_sigmoid.cu
@@ -1,6 +1,14 @@
-#include "kernels.h"
 #include <math.h>
+#include "kernels.h"
+#include "pluginsRT/ActivationSigmoidRT.h"
 
+// Static class fields initialization
+namespace tk { namespace dnn {
+nvinfer1::PluginFieldCollection ActivationSigmoidRTCreator::mFC{};
+std::vector<nvinfer1::PluginField> ActivationSigmoidRTCreator::mPluginAttributes;
+
+REGISTER_TENSORRT_PLUGIN(ActivationSigmoidRTCreator);
+}}
 
 __global__
 void activation_sigmoid(dnnType *input, dnnType *output, int size) {
@@ -18,6 +26,6 @@ void activationSIGMOIDForward(dnnType* srcData, dnnType* dstData, int size, cuda
 {
     int blocks = (size+255)/256;
     int threads = 256;
-    
+
     activation_sigmoid<<<blocks, threads, 0, stream>>>(srcData, dstData, size);
 }

--- a/src/kernels/pooling.cu
+++ b/src/kernels/pooling.cu
@@ -1,4 +1,13 @@
 #include "kernels.h"
+#include "pluginsRT/MaxPoolingFixedSizeRT.h"
+
+// Static class fields initialization
+namespace tk { namespace dnn {
+nvinfer1::PluginFieldCollection MaxPoolFixedSizeRTCreator::mFC{};
+std::vector<nvinfer1::PluginField> MaxPoolFixedSizeRTCreator::mPluginAttributes;
+
+REGISTER_TENSORRT_PLUGIN(MaxPoolFixedSizeRTCreator);
+}}
 
 __global__ void forward_maxpool_layer_kernel(int n, int in_h, int in_w, int in_c, int stride_x, int stride_y, int size, int pad, float *input, float *output)
 {
@@ -39,14 +48,14 @@ __global__ void forward_maxpool_layer_kernel(int n, int in_h, int in_w, int in_c
     output[out_index] = max;
 }
 
-void MaxPoolingForward(dnnType* srcData, dnnType* dstData, int n, int c, int h, int w, int stride_x, int stride_y, int size, int padding, cudaStream_t stream) 
+void MaxPoolingForward(dnnType* srcData, dnnType* dstData, int n, int c, int h, int w, int stride_x, int stride_y, int size, int padding, cudaStream_t stream)
 {
 
     int tot_size = n*c*h*w;
 
     int blocks = (tot_size+255)/256;
     int threads = 256;
-    
+
     forward_maxpool_layer_kernel<<<blocks, threads, 0, stream>>>(tot_size, h, w, c, stride_x, stride_y, size, padding, srcData, dstData);
 }
 

--- a/src/kernels/reorg.cu
+++ b/src/kernels/reorg.cu
@@ -1,4 +1,13 @@
 #include "kernels.h"
+#include "pluginsRT/ReorgRT.h"
+
+// Static class fields initialization
+namespace tk { namespace dnn {
+nvinfer1::PluginFieldCollection ReorgRTCreator::mFC{};
+std::vector<nvinfer1::PluginField> ReorgRTCreator::mPluginAttributes;
+
+REGISTER_TENSORRT_PLUGIN(ReorgRTCreator);
+}}
 
 __global__ void reorg_kernel(int N, float *x, int w, int h, int c, int batch, int stride, int forward, float *out)
 {
@@ -35,14 +44,14 @@ __global__ void reorg_kernel(int N, float *x, int w, int h, int c, int batch, in
 /**
     reorg function function
 */
-void reorgForward(dnnType* srcData, dnnType* dstData, 
+void reorgForward(dnnType* srcData, dnnType* dstData,
                   int n, int c, int h, int w, int stride, cudaStream_t stream) {
 
     int size = n*c*h*w;
 
     int blocks = (size+255)/256;
     int threads = 256;
-    
+
     reorg_kernel<<<blocks, threads, 0, stream>>>(size, srcData, w, h, c, n, stride, false, dstData);
 }
 

--- a/src/kernels/resize.cu
+++ b/src/kernels/resize.cu
@@ -1,7 +1,17 @@
-#include "kernels.h"
 #include <stdio.h>
 
-__global__ void resize_kernel(  int size,float *x, int i_w, int i_h, int i_c,  
+#include "kernels.h"
+#include "pluginsRT/ResizeLayerRT.h"
+
+// Static class fields initialization
+namespace tk { namespace dnn {
+nvinfer1::PluginFieldCollection ResizeLayerRTCreator::mFC{};
+std::vector<nvinfer1::PluginField> ResizeLayerRTCreator::mPluginAttributes;
+
+REGISTER_TENSORRT_PLUGIN(ResizeLayerRTCreator);
+}}
+
+__global__ void resize_kernel(  int size,float *x, int i_w, int i_h, int i_c,
                                 int o_w, int o_h, int o_c, int batch, float *out)
 {
     int id = (blockIdx.x + blockIdx.y*gridDim.x) * blockDim.x + threadIdx.x;

--- a/src/kernels/scaladd.cu
+++ b/src/kernels/scaladd.cu
@@ -1,5 +1,6 @@
-#include "kernels.h"
 #include <math.h>
+
+#include "kernels.h"
 
 __global__ void scal_add_kernel(dnnType* dstData, int size, float alpha, float beta, int inc)
 {
@@ -11,6 +12,6 @@ void scalAdd(dnnType* dstData, int size, float alpha, float beta, int inc, cudaS
 {
     int blocks = (size+255)/256;
     int threads = 256;
-    
+
     scal_add_kernel<<<blocks, threads, 0, stream>>>(dstData, size, alpha, beta, inc);
 }

--- a/src/kernels/static_init.cu
+++ b/src/kernels/static_init.cu
@@ -1,0 +1,33 @@
+#include "pluginsRT/RegionRT.h"
+#include "pluginsRT/RouteRT.h"
+#include "pluginsRT/ReshapeRT.h"
+#include "pluginsRT/FlattenConcatRT.h"
+#include "pluginsRT/YoloRT.h"
+
+// Static class fields initialization
+namespace tk { namespace dnn {
+nvinfer1::PluginFieldCollection RegionRTCreator::mFC{};
+std::vector<nvinfer1::PluginField> RegionRTCreator::mPluginAttributes;
+
+REGISTER_TENSORRT_PLUGIN(RegionRTCreator);
+
+nvinfer1::PluginFieldCollection RouteRTCreator::mFC{};
+std::vector<nvinfer1::PluginField> RouteRTCreator::mPluginAttributes;
+
+REGISTER_TENSORRT_PLUGIN(RouteRTCreator);
+
+nvinfer1::PluginFieldCollection ReshapeRTCreator::mFC{};
+std::vector<nvinfer1::PluginField> ReshapeRTCreator::mPluginAttributes;
+
+REGISTER_TENSORRT_PLUGIN(ReshapeRTCreator);
+
+nvinfer1::PluginFieldCollection FlattenConcatRTCreator::mFC{};
+std::vector<nvinfer1::PluginField> FlattenConcatRTCreator::mPluginAttributes;
+
+REGISTER_TENSORRT_PLUGIN(FlattenConcatRTCreator);
+
+nvinfer1::PluginFieldCollection YoloRTCreator::mFC{};
+std::vector<nvinfer1::PluginField> YoloRTCreator::mPluginAttributes;
+
+REGISTER_TENSORRT_PLUGIN(YoloRTCreator);
+}}

--- a/src/kernels/upsample.cu
+++ b/src/kernels/upsample.cu
@@ -1,4 +1,13 @@
 #include "kernels.h"
+#include "pluginsRT/UpsampleRT.h"
+
+// Static class fields initialization
+namespace tk { namespace dnn {
+nvinfer1::PluginFieldCollection UpsampleRTCreator::mFC{};
+std::vector<nvinfer1::PluginField> UpsampleRTCreator::mPluginAttributes;
+
+REGISTER_TENSORRT_PLUGIN(UpsampleRTCreator);
+}}
 
 __global__ void upsample_kernel(size_t N, dnnType *x, int w, int h, int c, int batch, int stride, int forward, float scale, dnnType *out)
 {
@@ -24,8 +33,8 @@ __global__ void upsample_kernel(size_t N, dnnType *x, int w, int h, int c, int b
     else atomicAdd(x+in_index, scale * out[out_index]);
 }
 
-void upsampleForward(dnnType* srcData, dnnType* dstData, 
-                     int n, int c, int h, int w, int s, int forward, float scale,                                   
+void upsampleForward(dnnType* srcData, dnnType* dstData,
+                     int n, int c, int h, int w, int s, int forward, float scale,
                      cudaStream_t stream) {
 
     int size = w*h*c*n*s*s;

--- a/src/yoloContainer.cpp
+++ b/src/yoloContainer.cpp
@@ -1,0 +1,41 @@
+#include "yoloContainer.h"
+#include "pluginsRT/YoloRT.h"
+
+namespace tk { namespace dnn {
+YoloContainer yoloContainer;
+
+nvinfer1::IPluginV2* YoloRTCreator::deserializePlugin(const char* name, const void* serialData, size_t serialLength) noexcept {
+  const char * buf = reinterpret_cast<const char*>(serialData),*bufCheck = buf;
+  int classes_temp = tk::dnn::readBUF<int>(buf);
+  int num_temp = tk::dnn::readBUF<int>(buf);
+  int n_masks_temp = tk::dnn::readBUF<int>(buf);
+  float scale_xy_temp = tk::dnn::readBUF<float>(buf);
+  float nms_thresh_temp = tk::dnn::readBUF<float>(buf);
+  int nms_kind_temp = tk::dnn::readBUF<int>(buf);
+  int new_coords_temp = tk::dnn::readBUF<int>(buf);
+
+  YoloRT *r = new YoloRT(classes_temp,num_temp,nullptr,n_masks_temp,scale_xy_temp,nms_thresh_temp,nms_kind_temp,new_coords_temp);
+
+  r->c = tk::dnn::readBUF<int>(buf);
+  r->h = tk::dnn::readBUF<int>(buf);
+  r->w = tk::dnn::readBUF<int>(buf);
+  for(int i=0; i<r->n_masks; i++)
+      r->mask[i] = tk::dnn::readBUF<dnnType>(buf);
+  for(int i=0; i<r->n_masks*2*r->num; i++)
+      r->bias[i] = tk::dnn::readBUF<dnnType>(buf);
+
+  // save classes names
+  r->classesNames.resize(r->classes);
+  for(int i=0; i<r->classes; i++) {
+          char tmp[YOLORT_CLASSNAME_W];
+    for(int j=0; j<YOLORT_CLASSNAME_W; j++)
+      tmp[j] = tk::dnn::readBUF<char>(buf);
+          r->classesNames[i] = std::string(tmp);
+  }
+  assert(buf == bufCheck + serialLength);
+
+  yoloContainer.yolos[yoloContainer.n_yolos++] = r;
+  return r;
+}
+
+}}


### PR DESCRIPTION
- Migrated to TRT8 API, but I didn't really try maintaining old compatibility. Lowest support now could be TRT6.
- Refactored some stuff that are bad C++ practices and made coding really hard, like including headers in namespaces or not using an include guard.
- Needed to move the yolo container outside tkdnn object, which means we now only have one and global. Deserialization in TRT8 doesn't happen in your object, but in the plugin itself so it couldn't access the yolo objects. I think the need to hold onto yolo layers itself is flawed and shouldn't be necessary.

I tested on an Xavier NX running Jetpack4.6 and at least the yolo4 network runs fine. Haven't tested all of them.

In the future I might do some more refactoring and cleanup, but not sure if then I would diverge a lot from what the maintainers are doing here. I think some performance can be gained from a cleanup and dropping some older compatibility (I think maybe TRT6 or even 7 should be the lowest now).

Also this project really needs a style guide :D