### PR TITLE
curl is missing to run test

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -4,7 +4,7 @@ LABEL maintainer "Francesco Gatti"
 ADD nv-tensorrt-repo-ubuntu1804-cuda10.2-trt7.0.0.11-ga-20191216_1-1_amd64.deb /tmp/trt.deb
 RUN apt-get update && dpkg -i /tmp/trt.deb && rm /tmp/trt.deb && apt-get update
 RUN apt install -y libnvinfer7=7.0.0-1+cuda10.2 libnvinfer-dev=7.0.0-1+cuda10.2
-RUN DEBIAN_FRONTEND=noninteractive apt install -y git wget libeigen3-dev libyaml-cpp-dev
+RUN DEBIAN_FRONTEND=noninteractive apt install -y git wget libeigen3-dev libyaml-cpp-dev curl
 RUN cd /tmp && \
     wget https://github.com/Kitware/CMake/releases/download/v3.17.3/cmake-3.17.3-Linux-x86_64.sh && \
     chmod +x cmake-3.17.3-Linux-x86_64.sh && \


### PR DESCRIPTION
root@2a3891735f20:~/tkDNN/build# ./test_yolo4_512 
mkdir: cannot create directory 'yolo4_512': File exists
sh: 1: curl: not found
unzip:  cannot find or open yolo4_512/weights.zip, yolo4_512/weights.zip.zip or yolo4_512/weights.zip.ZIP.
rm: cannot remove 'yolo4_512/weights.zip': No such file or directory



 As we install git here instead on https://github.com/ceccocats/tkDNN/blob/master/docker/Dockerfile i guess we can add curl here too.