### PR TITLE
Add installing libyaml-cpp-dev to docker/Dockerfile.base

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -128,6 +128,8 @@ RUN cd ~/build && \
 
 RUN cd ~ && rm -rf build
 
+RUN apt-get update && apt-get install -y libyaml-cpp-dev
+
 RUN cd ~ && mkdir Development && cd Development && \
 git clone https://github.com/ceccocats/tkDNN.git && cd tkDNN && \
 mkdir build && cd build && \


### PR DESCRIPTION
When building docker base image (from `docker/Dockerfile.base`), cmake was failing with the following:

```bash
CMake Error at CMakeLists.txt:91 (find_package):
  By not providing "Findyaml-cpp.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "yaml-cpp",
  but CMake did not find one.

  Could not find a package configuration file provided by "yaml-cpp" with any
  of the following names:

    yaml-cppConfig.cmake
    yaml-cpp-config.cmake

  Add the installation prefix of "yaml-cpp" to CMAKE_PREFIX_PATH or set
  "yaml-cpp_DIR" to a directory containing one of the above files.  If
  "yaml-cpp" provides a separate development package or SDK, be sure it has
  been installed.
```
Adding `RUN apt-get update && apt-get install -y libyaml-cpp-dev` to `Dockerfile.base` fixed the issue. 
