### PR TITLE
Compile error fixed by including header properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 build/
+installed/
 .vscode/
 *.bin
 *.pyc

--- a/include/tkDNN/DarknetParser.h
+++ b/include/tkDNN/DarknetParser.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <iostream>
-#include "tkDNN/tkdnn.h"
+#include "tkdnn.h"
 
 namespace tk { namespace dnn {
 

--- a/include/tkDNN/NetworkRT.h
+++ b/include/tkDNN/NetworkRT.h
@@ -7,7 +7,7 @@
 #include "Layer.h"
 #include "NvInfer.h"
 #include <memory>
-#include <tkDNN/kernels.h>
+#include "kernels.h"
 #include <pluginsRT/ActivationLeakyRT.h>
 #include <pluginsRT/ActivationLogisticRT.h>
 #include <pluginsRT/ActivationMishRT.h>


### PR DESCRIPTION
Or, "tkdnn.h" and "kernels.h" cannot be found within the changed header files.